### PR TITLE
adds redis monitoring support to riemann-tools.

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -2,15 +2,15 @@ require 'rubygems'
 require 'rubygems/package_task'
 require 'rdoc/task'
 require 'find'
- 
+
 # Don't include resource forks in tarballs on Mac OS X.
 ENV['COPY_EXTENDED_ATTRIBUTES_DISABLE'] = 'true'
 ENV['COPYFILE_DISABLE'] = 'true'
- 
+
 # Gemspec
 gemspec = Gem::Specification.new do |s|
   s.rubyforge_project = 'riemann-tools'
- 
+
   s.name = 'riemann-tools'
   s.version = '0.0.8'
   s.author = 'Kyle Kingsbury'
@@ -23,22 +23,23 @@ gemspec = Gem::Specification.new do |s|
   s.add_dependency 'trollop', '>= 1.16.2'
   s.add_dependency 'munin-ruby', '>= 0.2.1'
   s.add_dependency 'yajl-ruby', '>= 1.1.0'
+  s.add_dependency 'redis', '>= 3.0.2'
 
   s.files = FileList['lib/**/*', 'bin/*', 'LICENSE', 'README.markdown'].to_a
   s.executables |= Dir.entries('bin/')
   s.require_path = 'lib'
   s.has_rdoc = true
- 
+
   s.required_ruby_version = '>= 1.8.7'
 end
 
 Gem::PackageTask.new gemspec do |p|
 end
- 
+
 RDoc::Task.new do |rd|
   rd.main = 'Riemann Tools'
   rd.title = 'Riemann Tools'
   rd.rdoc_dir = 'doc'
- 
+
   rd.rdoc_files.include('lib/**/*.rb')
 end

--- a/bin/riemann-redis
+++ b/bin/riemann-redis
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+# Gathers redis INFO statistics and submits them to Riemann.
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::Redis
+  include Riemann::Tools
+  require 'redis'
+
+  opt :redis_host, "Redis hostname", :default => 'localhost'
+  opt :redis_port, "Redis port", :default => 6379
+  opt :redis_password, "Redis password", :default => ''
+
+  def initialize
+    @redis = ::Redis.new(:host => opts[:redis_host], :port => opts[:redis_port])
+    @redis.auth(opts[:redis_password]) unless opts[:redis_password] == ''
+  end
+
+  def tick
+    @redis.info.each do |property, value|
+      report(
+        :service => "redis #{property}",
+        :metric  => value.to_f,
+        :state   => 'ok',
+        :tags    => ['redis']
+      )
+    end
+  end
+
+end
+
+Riemann::Tools::Redis.run


### PR DESCRIPTION
I saw in your README that you had a plan to support redis, but I needed it now, so I wrote one. It relies on datasets that come from the INFO command (http://redis.io/commands/info). I publish everything that it provides me as "redis <property>" with a state: 'ok', and tags: ['redis']

Works like a charm! Any improvements I could make? This, adds a new gem dependency (redis-rb).
