### PR TITLE
adds haproxy statistics monitoring support for riemann.

### DIFF
--- a/bin/riemann-haproxy
+++ b/bin/riemann-haproxy
@@ -9,7 +9,7 @@ class Riemann::Tools::Haproxy
   require 'net/http'
   require 'csv'
 
-  opt :stats_url, "full url to haproxy stats (eg: https://user:password@host.com:9999/stats)", :required => true, :type => :string
+  opt :stats_url, "Full url to haproxy stats (eg: https://user:password@host.com:9999/stats)", :required => true, :type => :string
 
   def initialize
     @uri = URI(opts[:stats_url]+';csv')


### PR DESCRIPTION
Haproxy is a widely used open source tool for load balancing. Scratching my own itch, and I wanted to contribute this back to your project.

Here is an example of the keys/metrics that this monitor will output.
https://gist.github.com/0ddc54063717aee673d7

Let me know if you have any adjustments/enhancements you'd like to add.
