### PR TITLE
adds Cloudant.com shared cluster load balancer statistics/monitoring support

### DIFF
--- a/bin/riemann-cloudant
+++ b/bin/riemann-cloudant
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+# Gathers load balancer statistics from Cloudant.com (shared cluster) and submits them to Riemann.
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::Cloudant
+  include Riemann::Tools
+  require 'net/http'
+  require 'json'
+
+  opt :cloudant_username, "Cloudant username", :type => :string, :required => true
+  opt :cloudant_password, "Cloudant pasword", :type => :string, :required => true
+
+  def tick
+    json = JSON.parse(get_json().body)
+    json.each do |node|
+      return if node['svname'] == 'BACKEND' # this is just a sum of all nodes.
+
+      ns = "cloudant #{node['pxname']} #{node['tracked']}"
+      cluster_name = node['tracked'].split('.')[0] # ie: meritage.cloudant.com
+
+      # report health of each node.
+      report(
+        :service => ns,
+        :state   => (node['status'] == 'UP' ? 'ok' : 'critical'),
+        :tags    => ['cloudant', cluster_name]
+      )
+
+      # report property->metric of each node.
+      node.each do |property, metric|
+        unless ['pxname', 'svname', 'status', 'tracked'].include?(property)
+          report(
+            :service => "#{ns} #{property}",
+            :metric  => metric.to_f,
+            :state   => (node['status'] == 'UP' ? 'ok' : 'critical'),
+            :tags    => ['cloudant', cluster_name]
+          )
+        end
+      end
+
+    end
+  end
+
+   def get_json
+    http = Net::HTTP.new('cloudant.com', 443)
+    http.use_ssl = true
+      http.start do |h|
+        get = Net::HTTP::Get.new('/api/load_balancer')
+        get.basic_auth opts[:cloudant_username], opts[:cloudant_password]
+        h.request get
+     end
+   end
+
+end
+
+Riemann::Tools::Cloudant.run


### PR DESCRIPTION
Cloudant.com provides a hosted dynamodb-style implementation of CouchDB. This program adds uptime monitoring and haproxy-esque stats aggregation.

To see an example of what the stats look like, checkout this gist:
https://gist.github.com/eb4cbcd4f53153eaa579

The format is: cloudant > dbname > cluster node > metric

Requires a valid Cloudant account, which is passed to the program using `--cloudant-username` and `--cloudant-password'

Let me know if you would like me to make any changes to this!
