### PR TITLE
Reflect each haproxy config as its own unique status

### DIFF
--- a/bin/riemann-haproxy
+++ b/bin/riemann-haproxy
@@ -26,7 +26,7 @@ class Riemann::Tools::Haproxy
             :host    => @uri.host,
             :service => "#{ns} #{property}",
             :metric  => metric.to_f,
-            :state   =>  'ok',
+            :state   =>  (['UP', 'OPEN'].include?(row['status']) ? 'ok' : 'critical'),
             :tags    => ['haproxy']
           )
         end


### PR DESCRIPTION
This makes it so that you can trigger state changes based on individual configuration elements within an haproxy conf. ie: if a particular node in the balancer goes down, you can get state 'critical' for that single node.
