### PR TITLE
Fix core count on darwin

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -201,7 +201,7 @@ class Riemann::Tools::Health
       alert 'load', :unknown, nil, "unable to get load ave from top"
       return false
     end
-    metric = @topdata[:load] / cores
+    metric = @topdata[:load] / @cores
     if metric > @limits[:load][:critical]
       alert "load", :critical, metric, "15-minute load average per core is #{metric}"
     elsif metric > @limits[:load][:warning]


### PR DESCRIPTION
Got a stack trace when I tried to run riemann-health on mac os x lion. It called the linux core count code.
