### PR TITLE
fix overflowing text from ps by swapping args for comm

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -100,7 +100,7 @@ class Riemann::Tools::Health
       total = used + i2-i1
       fraction = used.to_f / total
 
-      report_pct :cpu, fraction, "user+nice+sytem\n\n#{`ps -eo pcpu,pid,args | sort -nrb -k1 | head -10`.chomp}"
+      report_pct :cpu, fraction, "user+nice+sytem\n\n#{`ps -eo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
     end
 
     @old_cpu = [u2, n2, s2, i2]
@@ -129,7 +129,7 @@ class Riemann::Tools::Health
     total = m['MemTotal'].to_i
     fraction = 1 - (free.to_f / total)
 
-    report_pct :memory, fraction, "used\n\n#{`ps -eo pmem,pid,args | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory, fraction, "used\n\n#{`ps -eo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end
 
   def freebsd_cpu
@@ -142,7 +142,7 @@ class Riemann::Tools::Health
       total = used + i2-i1
       fraction = used.to_f / total
 
-      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{`ps -axo pcpu,pid,args | sort -nrb -k1 | head -10`.chomp}"
+      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{`ps -axo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
     end
 
     @old_cpu = [u2, n2, s2, t2, i2]
@@ -164,7 +164,7 @@ class Riemann::Tools::Health
     meminfo = `sysctl -n vm.stats.vm.v_page_count vm.stats.vm.v_wire_count vm.stats.vm.v_active_count 2>/dev/null`.chomp.split
     fraction = (meminfo[1].to_f + meminfo[2].to_f) / meminfo[0].to_f
 
-    report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,args | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end
 
   def darwin_top
@@ -192,7 +192,7 @@ class Riemann::Tools::Health
       alert 'cpu', :unknown, nil, "unable to get CPU stats from top"
       return false
     end
-    report_pct :cpu,  @topdata[:cpu], "usage\n\n#{`ps -eo pcpu,pid,args | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :cpu,  @topdata[:cpu], "usage\n\n#{`ps -eo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end
 
   def darwin_load
@@ -217,7 +217,7 @@ class Riemann::Tools::Health
       alert 'memory', :unknown, nil, "unable to get memory data from top"
       return false
     end
-    report_pct :memory,  @topdata[:memory], "usage\n\n#{`ps -eo pmem,pid,args | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory,  @topdata[:memory], "usage\n\n#{`ps -eo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end
 
   def disk


### PR DESCRIPTION
Instead of sending full arguments list of process output, only send the command name.

fixes #16

On systems with multiple daemons and complex command lines running, it seems riemann-tools gets confused. There might be an underlying issue that causes UDP overflow, but this workaround seems sensible anyway.
- works on OSX
- works on ubuntu precise
- probably works on all reasonable unixes

On http://unixhelp.ed.ac.uk/CGI/man-cgi?ps find `comm` for what changed, or `man ps`.
