### PR TITLE
Typo in rieman-riak using :servie instead of :service

### DIFF
--- a/bin/riemann-riak
+++ b/bin/riemann-riak
@@ -66,7 +66,7 @@ class Riemann::Tools::Riak
     else
       report(
         :host => opts[:riak_host],
-        :servie => 'riak keys',
+        :service => 'riak keys',
         :state => 'unknown',
         :description => keys
       )


### PR DESCRIPTION
Was reading through the source and noticed this. Haven't tested it, but pretty sure it's a problem.
