### PR TITLE
Default event hostname

### DIFF
--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -28,6 +28,7 @@ module Riemann
         
         opt :host, "Riemann host", :default => '127.0.0.1'
         opt :port, "Riemann port", :default => 5555
+        opt :event_host, "Event hostname", :type => String
         opt :interval, "Seconds between updates", :default => 5
         opt :tag, "Tag to add to events", :type => String, :multi => true
         opt :ttl, "TTL for events", :type => Integer
@@ -61,6 +62,8 @@ module Riemann
       if options[:ttl]
         event[:ttl] = options[:ttl]
       end
+
+      event[:host] ||= options[:event_host]
 
       riemann << event
     end


### PR DESCRIPTION
Useful when trying riemann-health on a box to which you don't have access to change the hostname—like Heroku where `hostname` returns a GUID that's meaningless to you.
