### PR TITLE
Update host-val with even-host only if really set

### DIFF
--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -63,7 +63,9 @@ module Riemann
         event[:ttl] = options[:ttl]
       end
 
-      event[:host] ||= options[:event_host]
+      if options[:event_host]
+        event[:host] = options[:event_host]
+      end
 
       riemann << event
     end


### PR DESCRIPTION
event[:host] get's set unconditionally resulting in logging under host
null. Make sure we only set the value if the event-host variable has
been set.
