### PR TITLE
Fix incorrect resmon host vars

### DIFF
--- a/bin/riemann-resmon
+++ b/bin/riemann-resmon
@@ -26,7 +26,7 @@ class Riemann::Tools::Resmon
           req.options[:open_timeout] = options[:open_timeout]
         end
       rescue => e
-        report(:host => host,
+        report(:host => uri.host,
           :service => "resmon",
           :state => "critical",
           :description => "HTTP connection error: #{e.class} - #{e.message}"
@@ -44,7 +44,7 @@ class Riemann::Tools::Resmon
 
       # Handle non-200 responses
       if response.status != 200
-        report(:host => host,
+        report(:host => uri.host,
           :service => "resmon",
           :state => "critical",
           :description => "HTTP connection error: #{response.status} - #{response.body}"


### PR DESCRIPTION
Sorry! Hadn't tested the original PR properly. When I did test it it failed, as host doesn't exist, should have been uri.host.

I've tested this one and it seems to work fine :)
