### PR TITLE
Improve riemann-redis client

### DIFF
--- a/bin/riemann-redis
+++ b/bin/riemann-redis
@@ -13,6 +13,7 @@ class Riemann::Tools::Redis
   opt :redis_password, "Redis password", :default => ''
   opt :redis_url, "Redis URL", :default => ''
   opt :redis_socket, "Redis socket", :default => ''
+  opt :redis_section, "Redis INFO section", :default => 'default'
 
   STRING_VALUES = %w{ redis_version redis_git_sha1 redis_mode os
                       multiplexing_api gcc_version run_id used_memory_human
@@ -29,10 +30,11 @@ class Riemann::Tools::Redis
               end
     @redis = ::Redis.new(options)
     @redis.auth(opts[:redis_password]) unless opts[:redis_password] == ''
+    @section = opts[:redis_section]
   end
 
   def tick
-    @redis.info.each do |property, value|
+    @redis.info(@section).each do |property, value|
       data = {
         :host    => opts[:redis_host],
         :service => "redis #{property}",


### PR DESCRIPTION
Currently [`riemann-redis`](https://github.com/aphyr/riemann-tools/blob/master/bin/riemann-redis) tool only accepts host, port and (optional) password to connect to a Redis server. However it's better if it would additionally would accept an URL in case the user want to connect using via TCP or via socket. Auth is also possible to be specified from there for TCP connections.

Also it currently issues an [`INFO`](http://redis.io/commands/info) and sends all the data converted to float by using `#to_f`. While this conversion is possible for most of the values returned by `INFO`, some values are actually strings, which will be converted to `0` in that case, most notably `aof_last_bgrewrite_status` and `rdb_last_bgsave_status`, which reports `ok` or `error`.

Last but not least, Redis 2.6+ allows to query just for a section of the metrics, so it would be nice if each metric could be tagged properly depending on its section:
- `server`: General information about the Redis server
- `clients`: Client connections section
- `memory`: Memory consumption related information
- `persistence`: RDB and AOF related information
- `stats`: General statistics
- `replication`: Master/slave replication information
- `cpu`: CPU consumption statistics
- `commandstats`: Redis command statistics
- `cluster`: Redis Cluster section
- `keyspace`: Database related statistics

If anybody wants to join me, feel free to leave a comment, criticism or suggestion.
