### PR TITLE
Add a Redis SLOWLOG client

### DIFF
--- a/bin/riemann-redis-slowlog
+++ b/bin/riemann-redis-slowlog
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+# Gathers Redis SLOWLOG statistics and submits them to Riemann.
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::RedisSlowlog
+  include Riemann::Tools
+  require 'redis'
+
+  opt :redis_url,      "Redis URL",                        :default => 'redis://127.0.0.1:6379/'
+  opt :redis_password, "Redis password",                   :default => ''
+  opt :slowlog_len,    "Number of SLOWLOG entries to get", :default => 10
+  opt :slowlog_reset,  "Reset SLOWLOG after querying it",  :default => false
+
+  def initialize
+    @redis = ::Redis.new(url: opts[:redis_url])
+
+    @slowlog_len   = opts[:slowlog_len]
+    @slowlog_reset = opts[:slowlog_reset]
+
+    @redis.auth(opts[:redis_password]) unless opts[:redis_password] == ''
+  end
+
+  def tick
+    @redis.slowlog("GET", @slowlog_len).each do |id, timestamp, us, cmd|
+      data = {
+        :host        => @redis.client.host,
+        :service     => "redis",
+        :time        => timestamp,
+        :metric      => us.to_f,
+        :state       => 'warning',
+        :tags        => ['redis', 'slowlog'],
+        :description => cmd.inspect
+      }
+      report(data)
+    end
+
+    @redis.slowlog("RESET") if @slowlog_reset
+  end
+
+end
+
+Riemann::Tools::RedisSlowlog.run


### PR DESCRIPTION
The `riemann-redis-slowlog` client uses Redis' [`SLOGLOW`](http://redis.io/commands/slowlog) command in order to report those queries that exceeded a certain amount of time.

This client accepts the following CLI flags:
- `--redis-url, -d <s>`: Redis URL (default: redis://127.0.0.1:6379/)
- `--redis-password, -r <s>`: Redis password (default: "")
- `--slowlog-len, -s <i>`: Number of SLOWLOG entries to get (default: 10)
- `--slowlog-reset, -o`: Reset SLOWLOG after querying it (default: false)

The Redis SLOWLOG format returns the id, timestamp, microseconds spent while executing the command and an array of command and arguments sent to the Redis server. This last array is sent as a Ruby inspect string in the `description` field.

The service indicated by this client is `redis`. The state is always `warning`, and the tags sent with the reported event are `redis` and `slowlog`.
