### PR TITLE
riemann-nginx-status

### DIFF
--- a/bin/riemann-nginx-status
+++ b/bin/riemann-nginx-status
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+
+# Gathers nginx status stub statistics and submits them to Riemann.
+# See http://wiki.nginx.org/HttpStubStatusModule for configuring Nginx appropriately
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::NginxStatus
+  include Riemann::Tools
+  require 'net/http'
+  require 'uri'
+
+  opt :uri, "Nginx Stub Status URI", :default => 'http://localhost:8080/nginx_status'
+  opt :checks, "Which metrics to report.", :type => :strings, :default => %w{active accepted handled requests reading writing waiting}
+  opt :active_warning, "Active connections warning threshold", :default => 0
+  opt :active_critical, "Active connections critical threshold", :default => 0
+  opt :reading_warning, "Reading connections warning threshold", :default => 0
+  opt :reading_critical, "Reading connections critical threshold", :default => 0
+  opt :writing_warning, "Writing connections warning threshold", :default => 0
+  opt :writing_critical, "Writing connections critical threshold", :default => 0
+  opt :waiting_warning, "Waiting connections warning threshold", :default => 0
+  opt :waiting_critical, "Waiting connections critical threshold", :default => 0
+
+  def initialize
+    @uri = URI.parse(opts[:uri])
+
+    # sample response:
+    #
+    # Active connections: 1 
+    # server accepts handled requests
+    #  39 39 39 
+    # Reading: 0 Writing: 1 Waiting: 0 
+    @keys = %w{active accepted handled requests reading writing waiting}
+    @re = /Active connections: (\d+) \n.+\n (\d+) (\d+) (\d+) \nReading: (\d+) Writing: (\d+) Waiting: (\d+)/m
+  end
+
+  def state(key, value)
+    if opts.has_key? "#{key}_critical".to_sym
+      critical_threshold = opts["#{key}_critical".to_sym]
+      return 'critical' if critical_threshold > 0 and value >= critical_threshold
+    end
+
+    if opts.has_key? "#{key}_warning".to_sym
+      warning_threshold = opts["#{key}_warning".to_sym]
+      return 'warning' if warning_threshold > 0 and value >= warning_threshold
+    end
+
+    return 'ok'
+  end
+
+  def tick
+    response = Net::HTTP.get(@uri)
+    values = @re.match(response).to_a[1,7].map { |v| v.to_i }
+
+    @keys.zip(values).each do |key, value|
+      report({
+        :service => "nginx #{key}",
+        :metric  => value,
+        :state   => state(key, value),
+        :tags    => ['nginx']
+      })
+    end
+  end
+end
+
+Riemann::Tools::NginxStatus.run


### PR DESCRIPTION
This pull request is a new script to hit an Nginx stub status endpoint and report metrics back to Riemann.

Remaining concerns:
- This needs configuration through nginx. There's a link in a comment, but should it be explained more fully?
- The code probably sucks pretty bad, and needs to be reviewed by someone who knows what they're doing with Ruby. I know _enough_ to be dangerous, but not much more. I'll make any changes needed.

All that said, I've pushed this out to our servers already and it's working merrily along, pinging and reporting.

(implements #31)
