### PR TITLE
Add missing tx errors to riemann-net

### DIFF
--- a/bin/riemann-net
+++ b/bin/riemann-net
@@ -30,6 +30,7 @@ class Riemann::Tools::Net
         'rx multicast',
         'tx bytes',
         'tx packets',
+        'tx errs',
         'tx drops',
         'tx fifo',
         'tx colls',


### PR DESCRIPTION
I noticed that `tx errs` was missing from riemann-net, so I've added it in.

This could mess with peoples stats - if they've been pushing them to graphite etc, as they would have been getting errors reported as drops, drops as fifo etc.
