### PR TITLE
resmon: don't send metrics as strings

### DIFF
--- a/bin/riemann-resmon
+++ b/bin/riemann-resmon
@@ -78,7 +78,9 @@ class Riemann::Tools::Resmon
           }
 
           case metric.attributes['type'].value
-            when /[iIlLn]/
+            when /[iIlL]/
+              hash[:metric] = metric.text.to_i
+            when 'n'
               hash[:metric] = metric.text.to_f
             when 's'
               hash[:description] = metric.text


### PR DESCRIPTION
It will send the metric as an int or float, not string.

Strings were breaking things later on in our riemann config (graphite'y bits).
