### PR TITLE
Add support to create pidfile & move processing to background

### DIFF
--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -3,6 +3,7 @@ module Riemann
     require 'rubygems'
     require 'trollop'
     require 'riemann/client'
+    require 'daemons'
 
     def self.included(base)
       base.instance_eval do
@@ -32,6 +33,9 @@ module Riemann
         opt :interval, "Seconds between updates", :default => 5
         opt :tag, "Tag to add to events", :type => String, :multi => true
         opt :ttl, "TTL for events", :type => Integer
+        opt :daemonize, "Daemonize this process", :type => :boolean, :default => true, :short => :none
+        opt :daemonize_pid_dir, "pid process dir", :type => String , :default => '/tmp', :short => :none
+        
       end
     end
 
@@ -79,6 +83,19 @@ module Riemann
     alias :r :riemann
 
     def run
+      if (opts[:daemonize])
+        daemonsOptions = {
+          :backtrace  => true,
+          :dir        => opts[:daemonize_pid_dir],
+          :dir_mode   => :normal,
+#          :log_output => true,
+          :app_name   => File.basename($PROGRAM_NAME),
+        
+        }
+        puts "daemonize me, bitch! #{daemonsOptions}}"
+
+        Daemons.daemonize(daemonsOptions)
+      end
       t0 = Time.now
       loop do
         begin


### PR DESCRIPTION
I'm working on adding init scripts (*NIX) for riemann-tools and noticed the lack of PID File creation.  Additionally, I needed to move the riemann-tools processes to the background to allow the process to be daemonized.
- Add support to automatically create a pid file 
- Moved a few riemann-tools processes (HAProxy, Riak, health) to process in the background; 
