### PR TITLE
Add health status to riemann nginx

### DIFF
--- a/bin/riemann-nginx-status
+++ b/bin/riemann-nginx-status
@@ -49,7 +49,25 @@ class Riemann::Tools::NginxStatus
   end
 
   def tick
-    response = Net::HTTP.get(@uri)
+    response = nil
+    begin
+      response = Net::HTTP.get(@uri)
+    rescue => e
+      report(
+        :service => "nginx health",
+        :state => "critical",
+        :description => "Connection error: #{e.class} - #{e.message}"
+      )
+    end
+
+    return if response.nil?
+
+    report(
+      :service => "nginx health",
+      :state => "ok",
+      :description => "Nginx status connection ok"
+    )
+
     values = @re.match(response).to_a[1,7].map { |v| v.to_i }
 
     @keys.zip(values).each do |key, value|


### PR DESCRIPTION
If the connection to the nginx status page fails, set the health of
nginx to critical. Set it to be ok if the connection to the status page
works.

We've been using this to alert when nginx goes down or the status page
become unavailable. I feel it's a bit nicer this way, rather than
spamming the log with connection refused exceptions :)
