### PR TITLE
pass redis info fields' string value in status field

### DIFF
--- a/bin/riemann-redis
+++ b/bin/riemann-redis
@@ -39,7 +39,7 @@ class Riemann::Tools::Redis
         :host    => opts[:redis_host],
         :service => "redis #{property}",
         :metric  => value.to_f,
-        :state   => 'ok',
+        :state   => value.to_s,
         :tags    => ['redis']
       }
 


### PR DESCRIPTION
hi, 

  my use-case here is basically i want riemann to notice a state change when the "master link" field goes from "up" to "down" but that requires passing the string value through, ie the float in the metric isn't sufficient. 

thanks
