### PR TITLE
Fix small problems in riemann elasticsearch

### DIFF
--- a/bin/riemann-elasticsearch
+++ b/bin/riemann-elasticsearch
@@ -26,7 +26,7 @@ class Riemann::Tools::Elasticsearch
         end
       rescue => e
         report(:host => uri.host,
-          :service => "elasticsearch",
+          :service => "elasticsearch health",
           :state => "critical",
           :description => "HTTP connection error: #{e.class} - #{e.message}"
         )
@@ -46,7 +46,7 @@ class Riemann::Tools::Elasticsearch
 
     if response.status != 200
         report(:host => uri.host,
-          :service => "elasticsearch",
+          :service => "elasticsearch health",
           :state => "critical",
           :description => "HTTP connection error: #{response.status} - #{response.body}"
         )


### PR DESCRIPTION
- in the options "type" was spelt incorrectly
- when the http requests fail, an event is sent to record the failure, the service should be "elasticsearch health" so that it matches up with the health check later on in the tool, and therefore allow for events to recover after a cluster restart
