### PR TITLE
Set run_id property to zero

### DIFF
--- a/bin/riemann-redis
+++ b/bin/riemann-redis
@@ -52,6 +52,10 @@ class Riemann::Tools::Redis
           end
         end
 
+        if property == "run_id"
+          data[:metric] = 0
+        end
+
         report(data)
       end
     rescue ::Redis::CommandError => e


### PR DESCRIPTION
This closes #65 and will set the redis run_id property to 0.
