### PR TITLE
Dup service in riemann-net, work around frozen str

### DIFF
--- a/bin/riemann-net
+++ b/bin/riemann-net
@@ -87,7 +87,7 @@ class Riemann::Tools::Net
           end
 
         report(
-          :service => service,
+          :service => service.dup,
           :metric => (delta.to_f / opts[:interval]),
           :state => svc_state
         )


### PR DESCRIPTION
With riemann-tools 0.1.8 I was still hitting the
`RuntimeError can't modify frozen String`
error, using a freshly installed VM.

This PR should fix that up.
