### PR TITLE
Removed the option to pass section to redis info command.

### DIFF
--- a/bin/riemann-redis
+++ b/bin/riemann-redis
@@ -13,7 +13,6 @@ class Riemann::Tools::Redis
   opt :redis_password, "Redis password", :default => ''
   opt :redis_url, "Redis URL", :default => ''
   opt :redis_socket, "Redis socket", :default => ''
-  opt :redis_section, "Redis INFO section", :default => 'default'
 
   STRING_VALUES = %w{ redis_version redis_git_sha1 redis_mode os
                       multiplexing_api gcc_version run_id used_memory_human
@@ -30,12 +29,11 @@ class Riemann::Tools::Redis
               end
     @redis = ::Redis.new(options)
     @redis.auth(opts[:redis_password]) unless opts[:redis_password] == ''
-    @section = opts[:redis_section]
   end
 
   def tick
     begin
-      @redis.info(@section).each do |property, value|
+      @redis.info().each do |property, value|
         data = {
           :host    => opts[:redis_host].dup,
           :service => "redis #{property}",


### PR DESCRIPTION
Removed the option to pass section to redis info command. Option is no longer available and throws an exception when used.

We have this fix running in production on redis version: 2.2.12

passing any args from redis-cli such as INFO 'default' as described here http://redis.io/commands/info leads to an error.

The only possible command seems to be INFO with no parameters.  This is mirrored in the ruby gem.
