### PR TITLE
riemann proc regex should quote args to grep

### DIFF
--- a/bin/riemann-proc
+++ b/bin/riemann-proc
@@ -32,7 +32,7 @@ class Riemann::Tools::Proc
 
   def linux_proc
     process = opts[:proc_regex]
-    running = Integer(`ps axo args | grep #{process} | grep -v grep | grep -v riemann-proc | wc -l`)
+    running = Integer(`ps axo args | grep '#{process}' | grep -v grep | grep -v riemann-proc | wc -l`)
     if running > @limits[:critical][:max] or running < @limits[:critical][:min]
       alert "proc #{process}", :critical, running, "process #{process} is running #{running} instances"
     else


### PR DESCRIPTION
Without this, passing `--proc-regex "java -jar myjar.jar"` doesn't work - it interprets the space separator in the regex as separating arguments to grep.
