### PR TITLE
Fixed broken memory calculation for OSX Mavericks

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -196,6 +196,14 @@ class Riemann::Tools::Health
         used = mdat[7].to_i * (1024 ** "BKMGT".index(mdat[8]))
         free = mdat[9].to_i * (1024 ** "BKMGT".index(mdat[10]))
         @topdata[:memory] = (wired + active + used).to_f / (wired + active + used + inactive + free)
+      # This is for OSX Mavericks which
+      # uses a different format for top
+      # Example: PhysMem: 4662M used (1328M wired), 2782M unused.
+      elsif mdat = ln.match(/PhysMem: ([0-9]+)([BKMGT]) used \(([0-9]+)([BKMGT]) wired\), ([0-9]+)([BKMGT]) unused/i)
+        used  = mdat[1].to_i * (1024 ** "BKMGT".index(mdat[2]))
+        wired = mdat[3].to_i * (1024 ** "BKMGT".index(mdat[4]))
+        unused = mdat[5].to_i * (1024 ** "BKMGT".index(mdat[6]))
+        @topdata[:memory] = (used).to_f / (used + unused)
       end
     end
   end


### PR DESCRIPTION
In Mavericks the output of the top -l 1 command used changed from

PhysMem: 300M wired, 760M active, 497M inactive, 1557M used, 490M free.

to

PhysMem: 5034M used (1335M wired), 2402M unused.

This broke the memory calculation. Another elsif was added to the
darwin_top function to address this issue.
