### PR TITLE
Separate HAproxy's server state from server metrics

### DIFF
--- a/bin/riemann-haproxy
+++ b/bin/riemann-haproxy
@@ -26,11 +26,17 @@ class Riemann::Tools::Haproxy
             :host    => @uri.host,
             :service => "#{ns} #{property}",
             :metric  => metric.to_f,
-            :state   =>  (['UP', 'OPEN'].include?(row['status']) ? 'ok' : 'critical'),
             :tags    => ['haproxy']
           )
         end
       end
+
+      report(
+        :host    => @uri.host,
+        :service => "#{ns} state",
+        :state   => (['UP', 'OPEN'].include?(row['status']) ? 'ok' : 'critical'),
+        :tags    => ['haproxy']
+      )
     end
   end
 


### PR DESCRIPTION
Currently the server state is reported as state of each server metric. I think that this is wrong in two ways:
* Could be quite noisy - If the server goes down each of the server metrics will be sent as critical.
* This state is not relevant to the metric - The metric state should depend on thresholds (if such exist and can be defined at all). It does not make sense to send the same state everywhere.

Because of this I moved the server state in to separate event - "haproxy #{server} state".