### PR TITLE
Fix disk usage of riemann-health

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -27,7 +27,7 @@ class Riemann::Tools::Health
     case (ostype = `uname -s`.chomp.downcase)
     when 'darwin'
       @cores = `sysctl -n hw.ncpu`.to_i
-      @df = `df -P -t noiso9660`
+      @df = 'df -P -t noiso9660'
       @cpu = method :darwin_cpu
       @disk = method :disk
       @load = method :darwin_load
@@ -35,14 +35,14 @@ class Riemann::Tools::Health
       darwin_top
     when 'freebsd'
       @cores = `sysctl -n hw.ncpu`.to_i
-      @df = `df -P -t noiso9660`
+      @df = 'df -P -t noiso9660'
       @cpu = method :freebsd_cpu
       @disk = method :disk
       @load = method :freebsd_load
       @memory = method :freebsd_memory
     else
       @cores = cores
-      @df = `df -P --exclude-type=iso9660`
+      @df = 'df -P --exclude-type=iso9660'
       puts "WARNING: OS '#{ostype}' not explicitly supported. Falling back to Linux" unless ostype == "linux"
       @cpu = method :linux_cpu
       @disk = method :disk
@@ -246,7 +246,7 @@ class Riemann::Tools::Health
   end
 
   def disk
-    @df.split(/\n/).each do |r|
+    `#{@df}`.split(/\n/).each do |r|
       f = r.split(/\s+/)
       next if f[0] == 'Filesystem'
       next unless f[0] =~ /\// # Needs at least one slash in the mount path


### PR DESCRIPTION
Thanks for making these tools!

I ran into an issue where the disk usage reported by riemann-health was never changing.  It turns out that a [recent change](https://github.com/riemann/riemann-tools/commit/08fbe38d29b36eb874a4ed181bd381bf8b64a642) had the unfortunate side effect of caching the result of `df`.  This should fix it.