### PR TITLE
Make riemann-docker multithreaded

### DIFF
--- a/tools/riemann-docker/bin/riemann-docker
+++ b/tools/riemann-docker/bin/riemann-docker
@@ -202,8 +202,13 @@ class Riemann::Tools::DockerHealth
       end
     end
 
-    threads.each {|thr| thr.join }
-
+    threads.each do |thread|
+      begin
+        thread.join
+      rescue => e
+        $stderr.puts "#{e.class} #{e}\n#{e.backtrace.join "\n"}"
+      end
+    end
   end
 end
 

--- a/tools/riemann-docker/bin/riemann-docker
+++ b/tools/riemann-docker/bin/riemann-docker
@@ -179,24 +179,30 @@ class Riemann::Tools::DockerHealth
 
     # Get CPU, Memory and Load of each container
     containers = get_containers()
-    containers.each do |container|
+    threads = []
 
-      id = container.id
-      name = get_container_name(container)
+    containers.each do |ctr|
+      threads << Thread.new(ctr) do |container|
 
-      stats = Docker::Util.parse_json(container.connection.get("/containers/#{id}/stats", {stream:false}))
+        id = container.id
+        name = get_container_name(container)
 
-      if @basic_inspection_enabled
-        inspection = Docker::Util.parse_json(container.connection.get("/containers/#{id}/json"))
-        basic_inspection(id, name, inspection)
-      end
-      if @cpu_enabled
-        cpu(id, name, stats)
-      end
-      if @memory_enabled
-        memory(id, name, stats)
+        stats = Docker::Util.parse_json(container.connection.get("/containers/#{id}/stats", {stream:false}))
+
+        if @basic_inspection_enabled
+          inspection = Docker::Util.parse_json(container.connection.get("/containers/#{id}/json"))
+           basic_inspection(id, name, inspection)
+          end
+          if @cpu_enabled
+            cpu(id, name, stats)
+        end
+        if @memory_enabled
+          memory(id, name, stats)
+        end
       end
     end
+
+    threads.each {|thr| thr.join }
 
   end
 end


### PR DESCRIPTION
Apparently, getting container data from Docker may be slow (some of my requests to `/container/ID/stats` are longer than one second), and when you have a lot of containers running, events emitted from one container will expire before it gets enumerated again. 

Setting higher TTL looks and feels like a kludge; however, simultaneous requests to Docker API do not affect each other (much), so a simple solution is to make requests in parallel.

This small pull request does exactly that.