### PR TITLE
Corrected kvm running instance count

### DIFF
--- a/bin/riemann-kvminstance
+++ b/bin/riemann-kvminstance
@@ -8,7 +8,7 @@ class Riemann::Tools::KVM
   def tick
 
   #determine how many instances I have according to libvirt
-  kvm_instances = %x[virsh list |grep i-|wc -l]
+  kvm_instances = %x[LANG=C virsh list | grep -c running]
 
   #submit them to riemann
   report(


### PR DESCRIPTION
I had riemann-kvminstance reporting 0 all the time. I changed the line counting the instances.


Details:

The relevant line used to grep the virsh output:
```
 kvm_instances = %x[virsh list |grep i-|wc -l]
```
which is reporting 0 on the internationalized version:
```
[root@ernie ~]# LANG=C virsh list
 Id    Name                           State
----------------------------------------------------
 7     db1.kr.naetverk.net            running
 10    lb1.kr.naetverk.net            running
 11    www1.kr.naetverk.net           running

[root@ernie ~]# 
```

I changed it to a working one, forcing C output and avoiding one pipe:
```
  kvm_instances = %x[LANG=C virsh list | grep -c running]
```