### PR TITLE
JSON dependency version set to ~> 1.8

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -24,7 +24,7 @@ gemspec = Gem::Specification.new do |s|
 
   s.add_dependency 'riemann-client', '>= 0.2.2'
   s.add_dependency 'trollop', '>= 1.16.2'
-  s.add_dependency 'json'
+  s.add_dependency 'json', '~> 1.8'
 
   s.files = FileList['lib/**/*', 'bin/*', 'LICENSE', 'README.markdown'].to_a
   s.executables |= Dir.entries('bin/')


### PR DESCRIPTION
Reintroduces Ruby 1.9.3 compatibility,
JSON versions >= 2.0 require Ruby version >= 2.0
