### PR TITLE
Update riemann-proc

### DIFF
--- a/bin/riemann-proc
+++ b/bin/riemann-proc
@@ -50,7 +50,7 @@ class Riemann::Tools::Proc
     # value should be either process RSS, VSIZE, or 1 if running
     # state is always unknown for the moment
     #
-    ps_regex = /([0-9]+)[ ]+([0-9]+)[ ]+([0-9]+)[ ]+([A-Z])[ ]+([0-9:.]+)[ ]+[A-Za-z]{3}[ ]+([A-Za-z]{3} [0-9]+ [0-9:]+ [0-9]+)[ ]+(.*)/
+    ps_regex = /([0-9]+)[ ]+([0-9]+)[ ]+([0-9]+)[ ]+([A-Z])[ ]+([0-9:.]+)[ ]+[A-Za-z]{3}[ ]+([A-Za-z]{3}[ ]{1,2}[0-9]+ [0-9:]+ [0-9]+)[ ]+(.*)/
     found.each_line do |line|
       m = ps_regex.match(line)
       if not m.nil?


### PR DESCRIPTION
There's an issue where single digit dates (i.e. Oct  4 2016) won't be captured by regex because it contains two spaces instead of one.
