### PR TITLE
Add OpenBSD and Illumos (sunos in uname -s) to riemann-health

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -44,6 +44,12 @@ class Riemann::Tools::Health
       @disk = method :disk
       @load = method :bsd_load
       @memory = method :openbsd_memory
+    when 'sunos'
+      @cores = `mpstat -a 2>/dev/null`.split[33].to_i
+      @cpu = method :sunos_cpu
+      @disk = method :disk
+      @load = method :bsd_load
+      @memory = method :sunos_memory
     else
       @cores = `nproc`.to_i
       puts "WARNING: OS '#{@ostype}' not explicitly supported. Falling back to Linux" unless @ostype == "linux"
@@ -167,6 +173,30 @@ class Riemann::Tools::Health
     @old_cpu = [u2, n2, s2, t2, i2]
   end
 
+  def sunos_cpu
+    mpstats = `mpstat -a 2>/dev/null`.split
+    u2 = mpstats[29].to_i
+    s2 = mpstats[30].to_i
+    t2 = mpstats[31].to_i
+    i2 = mpstats[32].to_i
+
+    if @old_cpu
+      u1, s1, t1, i1 = @old_cpu
+
+      used = (u2+s2+t2) - (u1+s1+t1)
+      total = used + i2-i1
+      if i2 == i1 && used == 0 #If the system is <1% used in both samples then total will be 0 + (99 - 99), avoid a div by 0
+        fraction = 0
+      else
+        fraction = used.to_f / total
+      end
+
+      report_pct :cpu, fraction, "user+sytem+interrupt\n\n#{`ps -ao pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    end
+
+    @old_cpu = [u2, s2, t2, i2]
+  end
+
   def bsd_load
     m = `uptime`.split(':')[-1].chomp.gsub(/\s+/,'').split(',')
     load = m[0].to_f / @cores
@@ -191,6 +221,14 @@ class Riemann::Tools::Health
     fraction = meminfo[28].to_f / meminfo[29].to_f #The ratio of active to free memory unlike the others :(
 
     report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+  end
+
+  def sunos_memory
+    meminfo = `vmstat 2>/dev/null`.chomp.split
+    total_mem = `prtconf | grep Memory`.split[2].to_f * 1024 # reports in GB but vmstat is in MB
+    fraction = ( total_mem - meminfo[32].to_f ) / total_mem
+
+    report_pct :memory, fraction, "used\n\n#{`ps -ao pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end
 
   def darwin_top
@@ -258,6 +296,8 @@ class Riemann::Tools::Health
     case @ostype
     when 'darwin', 'freebsd', 'openbsd'
       `df -P -t noiso9660`
+    when 'sunos'
+      `df -P` # Is there a good way to exlude iso9660 here?
     else
       `df -P --exclude-type=iso9660`
     end

--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -36,8 +36,14 @@ class Riemann::Tools::Health
       @cores = `sysctl -n hw.ncpu`.to_i
       @cpu = method :freebsd_cpu
       @disk = method :disk
-      @load = method :freebsd_load
+      @load = method :bsd_load
       @memory = method :freebsd_memory
+    when 'openbsd'
+      @cores = `sysctl -n hw.ncpu`.to_i
+      @cpu = method :openbsd_cpu
+      @disk = method :disk
+      @load = method :bsd_load
+      @memory = method :openbsd_memory
     else
       @cores = `nproc`.to_i
       puts "WARNING: OS '#{@ostype}' not explicitly supported. Falling back to Linux" unless @ostype == "linux"
@@ -145,7 +151,23 @@ class Riemann::Tools::Health
     @old_cpu = [u2, n2, s2, t2, i2]
   end
 
-  def freebsd_load
+  def openbsd_cpu
+    u2, n2, s2, t2, i2 = `sysctl -n kern.cp_time 2>/dev/null`.split(',').map{ |e| e.to_i } #OpenBSD separates with ,
+
+    if @old_cpu
+      u1, n1, s1, t1, i1 = @old_cpu
+
+      used = (u2+n2+s2+t2) - (u1+n1+s1+t1)
+      total = used + i2-i1
+      fraction = used.to_f / total
+
+      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{`ps -axo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    end
+
+    @old_cpu = [u2, n2, s2, t2, i2]
+  end
+
+  def bsd_load
     m = `uptime`.split(':')[-1].chomp.gsub(/\s+/,'').split(',')
     load = m[0].to_f / @cores
     if load > @limits[:load][:critical]
@@ -160,6 +182,13 @@ class Riemann::Tools::Health
   def freebsd_memory
     meminfo = `sysctl -n vm.stats.vm.v_page_count vm.stats.vm.v_wire_count vm.stats.vm.v_active_count 2>/dev/null`.chomp.split
     fraction = (meminfo[1].to_f + meminfo[2].to_f) / meminfo[0].to_f
+
+    report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+  end
+
+  def openbsd_memory
+    meminfo = `vmstat 2>/dev/null`.chomp.split
+    fraction = meminfo[28].to_f / meminfo[29].to_f #The ratio of active to free memory unlike the others :(
 
     report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end
@@ -227,7 +256,7 @@ class Riemann::Tools::Health
 
   def df
     case @ostype
-    when 'darwin', 'freebsd'
+    when 'darwin', 'freebsd', 'openbsd'
       `df -P -t noiso9660`
     else
       `df -P --exclude-type=iso9660`


### PR DESCRIPTION
Both of these are based on the FreeBSD section that already existed. In fact I renamed freebsd_load to bsd_load because of reuse. I've used this on OpenBSD 5.9/Sparc64, OpenBSD 6.0/Sparc64, and an Illumos distribution, also on Sparc64. All of them using Ruby 2.3, though I don't think I used anything that isn't already used elsewhere so the Ruby version should be as constrained as prior.