### PR TITLE
hide riemann-tools parameters from process table

### DIFF
--- a/bin/riemann-apache-status
+++ b/bin/riemann-apache-status
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Collects Apache metrics and submits them to Riemann
 # More information can be found at http://httpd.apache.org/docs/2.4/mod/mod_status.html

--- a/bin/riemann-bench
+++ b/bin/riemann-bench
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Connects to a server (first arg) and populates it with a constant stream of
 # events for testing.

--- a/bin/riemann-cloudant
+++ b/bin/riemann-cloudant
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers load balancer statistics from Cloudant.com (shared cluster) and submits them to Riemann.
 

--- a/bin/riemann-consul
+++ b/bin/riemann-consul
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports service and node status to riemann
 

--- a/bin/riemann-dir-files-count
+++ b/bin/riemann-dir-files-count
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gets the number of files present on a directory and submits it to riemann
 

--- a/bin/riemann-dir-space
+++ b/bin/riemann-dir-space
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers the space used by a directory and submits it to riemann
 

--- a/bin/riemann-diskstats
+++ b/bin/riemann-diskstats
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 #
 require 'rubygems'
 require 'riemann/tools'

--- a/bin/riemann-fd
+++ b/bin/riemann-fd
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports current file descriptor use to riemann.
 # By default reports the total system fd usage, can also report usage of individual processes

--- a/bin/riemann-freeswitch
+++ b/bin/riemann-freeswitch
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require File.expand_path('../../lib/riemann/tools', __FILE__)
 

--- a/bin/riemann-haproxy
+++ b/bin/riemann-haproxy
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers haproxy CSV statistics and submits them to Riemann.
 

--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports current CPU, disk, load average, and memory use to riemann.
 

--- a/bin/riemann-kvminstance
+++ b/bin/riemann-kvminstance
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require File.expand_path('../../lib/riemann/tools', __FILE__)
 

--- a/bin/riemann-memcached
+++ b/bin/riemann-memcached
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers memcached STATS and submits them to Riemann.
 

--- a/bin/riemann-net
+++ b/bin/riemann-net
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers network interface statistics and submits them to Riemann.
 

--- a/bin/riemann-nginx-status
+++ b/bin/riemann-nginx-status
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers nginx status stub statistics and submits them to Riemann.
 # See http://wiki.nginx.org/HttpStubStatusModule for configuring Nginx appropriately

--- a/bin/riemann-ntp
+++ b/bin/riemann-ntp
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports NTP stats to Riemann.
 

--- a/bin/riemann-portcheck
+++ b/bin/riemann-portcheck
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Checks for open tcp ports.
 # (c) Max Voit 2017

--- a/bin/riemann-proc
+++ b/bin/riemann-proc
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports running process count to riemann.
 

--- a/bin/riemann-varnish
+++ b/bin/riemann-varnish
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports varnish stats to Riemann.
 

--- a/bin/riemann-zookeeper
+++ b/bin/riemann-zookeeper
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers zookeeper STATS and submits them to Riemann.
 

--- a/tools/riemann-aws/bin/riemann-aws-billing
+++ b/tools/riemann-aws/bin/riemann-aws-billing
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-aws/bin/riemann-aws-rds-status
+++ b/tools/riemann-aws/bin/riemann-aws-rds-status
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-aws/bin/riemann-aws-sqs-status
+++ b/tools/riemann-aws/bin/riemann-aws-sqs-status
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-aws/bin/riemann-aws-status
+++ b/tools/riemann-aws/bin/riemann-aws-status
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-aws/bin/riemann-elb-metrics
+++ b/tools/riemann-aws/bin/riemann-elb-metrics
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-aws/bin/riemann-s3-list
+++ b/tools/riemann-aws/bin/riemann-s3-list
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-aws/bin/riemann-s3-status
+++ b/tools/riemann-aws/bin/riemann-s3-status
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-chronos/bin/riemann-chronos
+++ b/tools/riemann-chronos/bin/riemann-chronos
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-docker/bin/riemann-docker
+++ b/tools/riemann-docker/bin/riemann-docker
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Reports current CPU, disk, load average, and memory use to riemann.
 

--- a/tools/riemann-elasticsearch/bin/riemann-elasticsearch
+++ b/tools/riemann-elasticsearch/bin/riemann-elasticsearch
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-marathon/bin/riemann-marathon
+++ b/tools/riemann-marathon/bin/riemann-marathon
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-mesos/bin/riemann-mesos
+++ b/tools/riemann-mesos/bin/riemann-mesos
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-munin/bin/riemann-munin
+++ b/tools/riemann-munin/bin/riemann-munin
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Gathers munin statistics and submits them to Riemann.
 

--- a/tools/riemann-rabbitmq/bin/riemann-rabbitmq
+++ b/tools/riemann-rabbitmq/bin/riemann-rabbitmq
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 require 'riemann/tools'
 

--- a/tools/riemann-riak/bin/riemann-riak
+++ b/tools/riemann-riak/bin/riemann-riak
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 # Forwards information on a Riak node to Riemann.
 

--- a/tools/riemann-riak/bin/riemann-riak-keys
+++ b/tools/riemann-riak/bin/riemann-riak-keys
@@ -1,4 +1,5 @@
 #!/usr/bin/env escript
+Process.setproctitle($0)
 %%! -name riakstatuscheck@127.0.0.1 -hidden
 
 main([]) -> main(["riak@127.0.0.1"]);

--- a/tools/riemann-riak/bin/riemann-riak-ring
+++ b/tools/riemann-riak/bin/riemann-riak-ring
@@ -1,4 +1,5 @@
 #!/usr/bin/env escript
+Process.setproctitle($0)
 %%! -name riakstatuscheck@127.0.0.1 -hidden
 
 main([]) -> main(["riak@127.0.0.1"]);

--- a/tools/riemann-riak/riak_status/key_count.erl
+++ b/tools/riemann-riak/riak_status/key_count.erl
@@ -1,4 +1,5 @@
 #!/usr/bin/env escript
+Process.setproctitle($0)
 %%! -name riakstatuscheck -setcookie riak -hidden
 
 main([]) -> main(["riak@127.0.0.1"]);

--- a/tools/riemann-riak/riak_status/riak_status.rb
+++ b/tools/riemann-riak/riak_status/riak_status.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+Process.setproctitle($0)
 
 $LOAD_PATH.unshift File.expand_path("#{File.dirname(__FILE__)}/../vodpod-common/lib")
 require 'rubygems'

--- a/tools/riemann-riak/riak_status/ringready.erl
+++ b/tools/riemann-riak/riak_status/ringready.erl
@@ -1,4 +1,5 @@
 #!/usr/bin/env escript
+Process.setproctitle($0)
 %%! -name riakstatuscheck -setcookie riak -hidden
 
 main([]) -> main(["riak@127.0.0.1"]);


### PR DESCRIPTION
Given that most riemann tools provide credentials on the command line, these are subsequently visible in process output. This is not ideal, and there is to my knowledge no particular need for these parameters to be visible.

This PR simply resets proctitle on platforms that support this on startup, keeping them from casual eyes. According to https://ruby-doc.org/core-2.3.0/Process.html this first appeared in Ruby 2.1, and has no effect on platforms that do not support it::

> Sets the process title that appears on the ps(1) command. Not necessarily effective on all platforms. No exception will be raised regardless of the result, nor will NotImplementedError be raised even if the platform does not support the feature. Calling this method does not affect the value of $0.

Credit to @nupfel for the idea and patch