### PR TITLE
Implement automated docker builds of included tools.

### DIFF
--- a/.docker/Dockerfile.tmpl
+++ b/.docker/Dockerfile.tmpl
@@ -1,0 +1,7 @@
+FROM ruby:2.5-alpine3.8
+RUN apk add --update alpine-sdk
+
+ARG RUBY_GEMS=""
+RUN gem install --verbose --no-rdoc --no-ri $RUBY_GEMS
+
+CMD ["riemann-health", "--help"]

--- a/.docker/publish.sh
+++ b/.docker/publish.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null && pwd)"
+IMAGE_PREFIX=${IMAGE_PREFIX:-"riemannio/"}
+
+function getVersion {
+	local path=$ROOT_DIR
+	[ -z "$1" ] || path="$ROOT_DIR/tools/$1"
+	cat $path/Rakefile.rb | grep s.version | grep -oE '[0-9.]{5,}'
+}
+
+function getPackageList {
+	echo -n "riemann-tools:`getVersion`"
+	[ -z "$1" ] || echo -n " $1:`getVersion $1`"
+}
+
+function dockerfile {
+	local packages=`getPackageList $1`
+	sed "s/^ARG RUBY_GEMS=.*/ARG RUBY_GEMS=\"$packages\"/" < $ROOT_DIR/.docker/Dockerfile.tmpl
+}
+
+# Need to log in before we can push.
+[ -z "$DOCKER_USER" ] && echo "DOCKER_USER is not set" && exit 1
+[ -z "$DOCKER_PASS" ] && echo "DOCKER_PASS is not set" && exit 1
+docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+tool=${EXTRA_TOOL:-""}
+version=`getVersion $tool`
+name=${IMAGE_PREFIX}riemann-tools${tool/riemann/}
+
+echo "==> Publishing $name:$version and :latest"
+dockerfile $tool | docker build --cache-from $name:latest -f - -t $name:$version -t $name:latest $ROOT_DIR/.docker
+docker push $name:$version
+docker push $name:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+env:
+  - EXTRA_TOOL=
+  - EXTRA_TOOL=riemann-aws
+  - EXTRA_TOOL=riemann-chronos
+  - EXTRA_TOOL=riemann-docker
+  - EXTRA_TOOL=riemann-elasticsearch
+  - EXTRA_TOOL=riemann-marathon
+  - EXTRA_TOOL=riemann-mesos
+  - EXTRA_TOOL=riemann-munin
+  - EXTRA_TOOL=riemann-rabbitmq
+  - EXTRA_TOOL=riemann-riak
+
+before_script:
+  - docker version
+
+script:
+  - .docker/publish.sh
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
This fixes #189

You will need to configure travis with the variables:
- `DOCKER_USER` your username on hub.docker.com
- `DOCKER_PASS` your password on hub.docker.com
- `IMAGE_PREFIX` (optional, default `riemannio/`) lets you store the images in a different namespace or private docker registry.

It will create multiple images. `riemann-tools` being the base binaries, like riemann-health. The additional tools are available as different images, for example `riemann-tools-docker` contains riemann-docker on top of the base binaries.
