### PR TITLE
Removed sed and fixed build caching.

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5-alpine3.8
 RUN apk add --update alpine-sdk
 
-ARG RUBY_GEMS=""
+ARG RUBY_GEMS="riemann-tools"
 RUN gem install --verbose --no-rdoc --no-ri $RUBY_GEMS
 
 CMD ["riemann-health", "--help"]


### PR DESCRIPTION
Initially I had planned on committing a single fat dockerfile that had all the tools and used that sed part to update gem the versions automatically. Now that it doesn't write files, it's easier to use `--build-arg`.

Also, for `--cache-from` you should manually call pull first. Forgotten about that.