### PR TITLE
Fix df --exclude-type on alpine

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -58,6 +58,7 @@ class Riemann::Tools::Health
       @disk = method :disk
       @load = method :linux_load
       @memory = method :linux_memory
+      @supports_exclude_type = `df --help 2>&1 | grep -e "--exclude-type"` != ""
     end
 
     opts[:checks].each do |check|
@@ -300,7 +301,11 @@ class Riemann::Tools::Health
     when 'sunos'
       `df -P` # Is there a good way to exlude iso9660 here?
     else
-      `df -P --exclude-type=iso9660`
+      if @supports_exclude_type
+        `df -P --exclude-type=iso9660`
+      else
+        `df -P`
+      end
     end
   end
 


### PR DESCRIPTION
Alpine's `df` does not support `--exclude-type`.
This detect this using `--help`.

A small compose file to reproduce the issue with the current version:

```yml
version: '3.3'
services:
  riemann-server:
    image: riemannio/riemann

  riemann-health:
    image: riemannio/riemann-tools:0.2.14
    command: riemann-health --host=riemann-server --checks=disk
```

Will output:

```
riemann-health_1  | df: unrecognized option: exclude-type=iso9660
riemann-health_1  | BusyBox v1.28.4 (2018-07-17 15:21:40 UTC) multi-call binary.
riemann-health_1  | 
riemann-health_1  | Usage: df [-PkmhTai] [-B SIZE] [FILESYSTEM]...
riemann-health_1  | 
riemann-health_1  | Print filesystem usage statistics
riemann-health_1  | 
riemann-health_1  | 	-P	POSIX output format
riemann-health_1  | 	-k	1024-byte blocks (default)
riemann-health_1  | 	-m	1M-byte blocks
riemann-health_1  | 	-h	Human readable (e.g. 1K 243M 2G)
riemann-health_1  | 	-T	Print filesystem type
riemann-health_1  | 	-a	Show all filesystems
riemann-health_1  | 	-i	Inodes
riemann-health_1  | 	-B SIZE	Blocksize
```