### PR TITLE
Add support for TLS

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -22,7 +22,7 @@ gemspec = Gem::Specification.new do |s|
   s.description = 'Collection of utilities which submit events to Riemann.'
   s.license = 'MIT'
 
-  s.add_runtime_dependency 'riemann-client', '~> 0.2', '>= 0.2.6'
+  s.add_runtime_dependency 'riemann-client', '~> 1.0'
   s.add_runtime_dependency 'optimist', '~> 3.0', '>= 3.0.0'
   s.add_runtime_dependency 'json', '>= 1.8'
 

--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -34,6 +34,11 @@ module Riemann
         opt :attribute, "Attribute to add to the event", :type => String, :multi => true
         opt :timeout, "Timeout (in seconds) when waiting for acknowledgements", :default => 30
         opt :tcp, "Use TCP transport instead of UDP (improves reliability, slight overhead.", :default => true
+        opt :tls, "Use TLS for securing traffic", :default => false
+        opt :tls_key, "TLS Key to use when using TLS", :type => String
+        opt :tls_cert, "TLS Certificate to use when using TLS", :type => String
+        opt :tls_ca_cert, "Trusted CA Certificate when using TLS", :type => String
+        opt :tls_verify, "Verify TLS peer when using TLS", :default => true
       end
     end
 
@@ -73,9 +78,14 @@ module Riemann
       r = Riemann::Client.new(
         :host    => options[:host],
         :port    => options[:port],
-        :timeout => options[:timeout]
+        :timeout => options[:timeout],
+        :ssl        => options[:tls],
+        :key_file   => options[:tls_key],
+        :cert_file  => options[:tls_cert],
+        :ca_file    => options[:tls_ca_cert],
+        :ssl_verify => options[:tls_verify],
       )
-      if options[:tcp]
+      if options[:tcp] || options[:tls]
         r.tcp
       else
         r


### PR DESCRIPTION
With https://github.com/riemann/riemann-ruby-client/pull/33 in the _riemann-client_ gem, we can bring support for TLS to _riemann-tools_!

Fixes #142