### PR TITLE
Fix cpu and memory usage sorting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+          - 2.7
+          - 3.0
+          - 3.1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run the test suite
+        run: bundle exec rspec

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--format doc

--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -4,9 +4,11 @@ Process.setproctitle($0)
 # Reports current CPU, disk, load average, and memory use to riemann.
 
 require File.expand_path('../../lib/riemann/tools', __FILE__)
+require File.expand_path('../../lib/riemann/tools/utils', __FILE__)
 
 class Riemann::Tools::Health
   include Riemann::Tools
+  include Riemann::Tools::Utils
 
   opt :cpu_warning, "CPU warning threshold (fraction of total jiffies)", :default => 0.9
   opt :cpu_critical, "CPU critical threshold (fraction of total jiffies)", :default => 0.95
@@ -111,7 +113,7 @@ class Riemann::Tools::Health
       total = used + i2-i1
       fraction = used.to_f / total
 
-      report_pct :cpu, fraction, "user+nice+system\n\n#{`ps -eo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+      report_pct :cpu, fraction, "user+nice+system\n\n#{reverse_numeric_sort_with_header(`ps -eo pcpu,pid,comm`)}"
     end
 
     @old_cpu = [u2, n2, s2, i2]
@@ -140,7 +142,7 @@ class Riemann::Tools::Health
     total = m['MemTotal'].to_i
     fraction = 1 - (free.to_f / total)
 
-    report_pct :memory, fraction, "used\n\n#{`ps -eo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory, fraction, "used\n\n#{reverse_numeric_sort_with_header(`ps -eo pmem,pid,comm`)}"
   end
 
   def freebsd_cpu
@@ -153,7 +155,7 @@ class Riemann::Tools::Health
       total = used + i2-i1
       fraction = used.to_f / total
 
-      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{`ps -axo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{reverse_numeric_sort_with_header(`ps -axo pcpu,pid,comm`)}"
     end
 
     @old_cpu = [u2, n2, s2, t2, i2]
@@ -169,7 +171,7 @@ class Riemann::Tools::Health
       total = used + i2-i1
       fraction = used.to_f / total
 
-      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{`ps -axo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+      report_pct :cpu, fraction, "user+nice+sytem+interrupt\n\n#{reverse_numeric_sort_with_header(`ps -axo pcpu,pid,comm`)}"
     end
 
     @old_cpu = [u2, n2, s2, t2, i2]
@@ -193,7 +195,7 @@ class Riemann::Tools::Health
         fraction = used.to_f / total
       end
 
-      report_pct :cpu, fraction, "user+sytem+interrupt\n\n#{`ps -ao pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+      report_pct :cpu, fraction, "user+sytem+interrupt\n\n#{reverse_numeric_sort_with_header(`ps -ao pcpu,pid,comm`)}"
     end
 
     @old_cpu = [u2, s2, t2, i2]
@@ -215,14 +217,14 @@ class Riemann::Tools::Health
     meminfo = `sysctl -n vm.stats.vm.v_page_count vm.stats.vm.v_wire_count vm.stats.vm.v_active_count 2>/dev/null`.chomp.split
     fraction = (meminfo[1].to_f + meminfo[2].to_f) / meminfo[0].to_f
 
-    report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory, fraction, "used\n\n#{reverse_numeric_sort_with_header(`ps -axo pmem,pid,comm`)}"
   end
 
   def openbsd_memory
     meminfo = `vmstat 2>/dev/null`.chomp.split
     fraction = meminfo[28].to_f / meminfo[29].to_f #The ratio of active to free memory unlike the others :(
 
-    report_pct :memory, fraction, "used\n\n#{`ps -axo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory, fraction, "used\n\n#{reverse_numeric_sort_with_header(`ps -axo pmem,pid,comm`)}"
   end
 
   def sunos_memory
@@ -230,7 +232,7 @@ class Riemann::Tools::Health
     total_mem = `prtconf | grep Memory`.split[2].to_f * 1024 # reports in GB but vmstat is in MB
     fraction = ( total_mem - meminfo[32].to_f ) / total_mem
 
-    report_pct :memory, fraction, "used\n\n#{`ps -ao pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory, fraction, "used\n\n#{reverse_numeric_sort_with_header(`ps -ao pmem,pid,comm`)}"
   end
 
   def darwin_top
@@ -266,7 +268,7 @@ class Riemann::Tools::Health
       alert 'cpu', :unknown, nil, "unable to get CPU stats from top"
       return false
     end
-    report_pct :cpu,  @topdata[:cpu], "usage\n\n#{`ps -eo pcpu,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :cpu,  @topdata[:cpu], "usage\n\n#{reverse_numeric_sort_with_header(`ps -eo pcpu,pid,comm`)}"
   end
 
   def darwin_load
@@ -291,7 +293,7 @@ class Riemann::Tools::Health
       alert 'memory', :unknown, nil, "unable to get memory data from top"
       return false
     end
-    report_pct :memory,  @topdata[:memory], "usage\n\n#{`ps -eo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
+    report_pct :memory,  @topdata[:memory], "usage\n\n#{reverse_numeric_sort_with_header(`ps -eo pmem,pid,comm`)}"
   end
 
   def df

--- a/lib/riemann/tools/utils.rb
+++ b/lib/riemann/tools/utils.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Riemann
+  module Tools
+    module Utils # :nodoc:
+      def reverse_numeric_sort_with_header(data, header: 1, count: 10)
+        lines = data.chomp.split("\n")
+        header = lines.shift(header)
+
+        lines.sort_by!(&:to_f)
+        lines.reverse!
+
+        (header + lines[0, count]).join("\n")
+      end
+    end
+  end
+end

--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'optimist', '~> 3.0', '>= 3.0.0'
   spec.add_runtime_dependency 'riemann-client', '~> 1.0'
+
+  spec.add_development_dependency 'rspec'
 end

--- a/spec/riemann/tools/utils_spec.rb
+++ b/spec/riemann/tools/utils_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/utils'
+
+class TestClass
+  include Riemann::Tools::Utils
+end
+
+RSpec.describe Riemann::Tools::Utils do
+  context('#reverse_numeric_sort_with_header') do
+    subject { TestClass.new.reverse_numeric_sort_with_header(input) }
+
+    let(:input) do
+      <<~INPUT
+        Header
+        11
+         1
+         2
+         8
+        10
+         3
+         4
+        14
+         5
+        12
+         7
+        13
+        15
+         9
+         6
+      INPUT
+    end
+    it { is_expected.to eq("Header\n15\n14\n13\n12\n11\n10\n 9\n 8\n 7\n 6") }
+
+    context 'with a number of data lines' do
+      subject { TestClass.new.reverse_numeric_sort_with_header(input, count: 3) }
+      it { is_expected.to eq("Header\n15\n14\n13") }
+    end
+
+    context 'with a number of header lines' do
+      subject { TestClass.new.reverse_numeric_sort_with_header(input, header: 3) }
+      it { is_expected.to eq("Header\n11\n 1\n15\n14\n13\n12\n10\n 9\n 8\n 7\n 6\n 5") }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+RSpec.configure do |config|
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
+  config.disable_monkey_patching!
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  config.warnings = true
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
When listing processes to fill-in the description of CPU and memory
events, the first line of the output from ps(1) is mixed with the rest
of the output which list processes which can result in weird reports
where the header line is mixed with the rest of the output:

```
root@theremin ~ # ps -eo pcpu,pid,comm | sort -nrb -k1 | head -10
 3.2    2216 corosync
 1.1    2268 pvestatd
%CPU     PID COMMAND
 0.4  460190 fail2ban-server
 0.4    2266 pve-firewall
 0.3    2857 systemd
 0.3    2386 systemd
 0.3    1089 z_rd_int_1
 0.3    1088 z_rd_int_0
 0.2    2138 pmxcfs
```

Add a utility function for sorting lines by reverse numeric value while
keeping the header line untouched.

While here, introduce some CI with GitHub actions.