### PR TITLE
Improve interface matching flexibility

### DIFF
--- a/spec/riemann/tools/net_spec.rb
+++ b/spec/riemann/tools/net_spec.rb
@@ -4,6 +4,7 @@ require 'riemann/tools/net'
 
 RSpec.describe Riemann::Tools::Net do
   context('#state') do
+    let(:state) { subject.state }
     it 'finds all interfaces' do
       allow(File).to receive(:read).with('/proc/net/dev').and_return(<<~CONTENT)
       Inter-|   Receive                                                |  Transmit
@@ -14,7 +15,7 @@ RSpec.describe Riemann::Tools::Net do
       br-1c33f552db55:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
       CONTENT
 
-      expect(subject.state).to eq({
+      expect(state).to eq({
        "docker0 rx bytes" => 0,
        "docker0 rx compressed" => 0,
        "docker0 rx drop" => 0,
@@ -64,6 +65,41 @@ RSpec.describe Riemann::Tools::Net do
        "br-1c33f552db55 tx fifo" => 0,
        "br-1c33f552db55 tx packets" => 0,
       })
+    end
+
+    it 'select interfaces using regexp' do
+      subject.instance_variable_set('@interfaces', ['enp'])
+      subject.instance_variable_set('@ignore_interfaces', [])
+      allow(File).to receive(:read).with('/proc/net/dev').and_return(<<~CONTENT)
+      Inter-|   Receive                                                |  Transmit
+       face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+          lo: 165480372  191253    0    0    0     0          0         0 165480372  191253    0    0    0     0       0          0
+      enp2s0: 1318001616 2106881    0    0    0     0          0         1 162233326 1866816    0    0    0     0       0          0
+      docker0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+      br-1c33f552db55:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+      CONTENT
+
+      expect(state).not_to include({ "lo rx bytes" => 165480372 })
+      expect(state).to include({ "enp2s0 rx bytes" => 1318001616 })
+      expect(state).not_to include({ "docker0 rx bytes" => 0 })
+      expect(state).not_to include({ "br-1c33f552db55 rx bytes" => 0 })
+    end
+
+    it 'ignore interfaces using regexp' do
+      subject.instance_variable_set('@ignore_interfaces', ['br'])
+      allow(File).to receive(:read).with('/proc/net/dev').and_return(<<~CONTENT)
+      Inter-|   Receive                                                |  Transmit
+       face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+          lo: 165480372  191253    0    0    0     0          0         0 165480372  191253    0    0    0     0       0          0
+      enp2s0: 1318001616 2106881    0    0    0     0          0         1 162233326 1866816    0    0    0     0       0          0
+      docker0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+      br-1c33f552db55:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+      CONTENT
+
+      expect(state).to include({ "lo rx bytes" => 165480372 })
+      expect(state).to include({ "enp2s0 rx bytes" => 1318001616 })
+      expect(state).to include({ "docker0 rx bytes" => 0 })
+      expect(state).not_to include({ "br-1c33f552db55 rx bytes" => 0 })
     end
   end
 end


### PR DESCRIPTION
Treat --interfaces and --ignore-interfaces as lists of patterns to match
network interface names instead of explicit interface names.

This allows to filter trancient interfaces that pop up and down all the
time with Docker (I am looking at you `br-XXXXXXXXXXXX` and `vethXXXXXXX`).

While here reject empty interface names, and simplify a bit the state
function.
