### PR TITLE
Add support for FreeBSD system fd monitoring

### DIFF
--- a/bin/riemann-fd
+++ b/bin/riemann-fd
@@ -21,8 +21,13 @@ class Riemann::Tools::Health
       :process => {:critical => opts[:fd_proc_critical], :warning => opts[:fd_proc_warning]},
     }
     ostype = `uname -s`.chomp.downcase
-    puts "WARNING: OS '#{ostype}' not explicitly supported. Falling back to Linux" unless ostype == "linux"
-    @fd = method :linux_fd
+    case ostype
+    when 'freebsd'
+      @fd = method :freebsd_fd
+    else
+      puts "WARNING: OS '#{ostype}' not explicitly supported. Falling back to Linux" unless ostype == "linux"
+      @fd = method :linux_fd
+    end
   end
 
   def alert(service, state, metric, description)
@@ -32,6 +37,17 @@ class Riemann::Tools::Health
       :metric => metric.to_f,
       :description => description
     )
+  end
+
+  def freebsd_fd
+    sys_used = Integer(`sysctl -n kern.openfiles`)
+    if sys_used > @limits[:fd][:critical]
+      alert "fd sys", :critical, sys_used, "system is using #{sys_used} fds"
+    elsif sys_used > @limits[:fd][:warning]
+      alert "fd sys", :warning, sys_used, "system is using #{sys_used} fds"
+    else
+      alert "fd sys", :ok, sys_used, "system is using #{sys_used} fds"
+    end
   end
 
   def linux_fd


### PR DESCRIPTION
Rely on the `kern.openfiles` sysctl instead of the presence of `lsof(1)`
on the system.  Using libffi we could replace the command invocation
with a bunch of calls to libc functions but this would require extra
dependencies which might be premature in this case.  So for now just run
`sysctl(1)`.