### PR TITLE
Ignore overlay filesystems by default

### DIFF
--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -14,7 +14,7 @@ module Riemann
       opt :disk_warning, 'Disk warning threshold (fraction of space used)', default: 0.9
       opt :disk_critical, 'Disk critical threshold (fraction of space used)', default: 0.95
       opt :disk_ignorefs, 'A list of filesystem types to ignore',
-          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs fdescfs iso9660 linprocfs linsysfs nfs procfs tmpfs]
+          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs tmpfs]
       opt :load_warning, 'Load warning threshold (load average / core)', default: 3.0
       opt :load_critical, 'Load critical threshold (load average / core)', default: 8.0
       opt :memory_warning, 'Memory warning threshold (fraction of RAM)', default: 0.85


### PR DESCRIPTION
In the Linux world, filesystem overlays allows to mount a directory on
top of another directory.  Because we already collect usage information
for the filesystems that contain the "lower" layer, we do not need to
collect information about the "upper" layer which dupplicate the same
information.

This helps avoiding transcient data about short-lived filesystems
created e.g. by CI systems that rely on Docker.
