### PR TITLE
Add uptime monitoring to riemann-health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Build the parser
+        run: bundle exec rake gen_parser
       - name: Run the test suite
         run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/
 .DS_Store
 .*.swp
 *.log
+lib/riemann/tools/uptime_parser.tab.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,8 @@
 ---
+AllCops:
+  Exclude:
+    - lib/riemann/tools/uptime_parser.tab.rb
+    - vendor/bundle/**/*
 Layout/HashAlignment:
   EnforcedHashRocketStyle: table
 Layout/LineLength:

--- a/Rakefile
+++ b/Rakefile
@@ -21,3 +21,12 @@ task :rbuild do
     Dir.chdir('../..')
   end
 end
+
+task build: :gen_parser
+
+desc 'Generate the uptime parser'
+task gen_parser: 'lib/riemann/tools/uptime_parser.tab.rb'
+
+file 'lib/riemann/tools/uptime_parser.tab.rb' => 'lib/riemann/tools/uptime_parser.y' do
+  sh 'racc -S lib/riemann/tools/uptime_parser.y'
+end

--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -2,6 +2,7 @@
 
 require 'riemann/tools'
 require 'riemann/tools/utils'
+require 'riemann/tools/uptime_parser.tab'
 
 module Riemann
   module Tools
@@ -204,9 +205,16 @@ module Riemann
         @old_cpu = [u2, s2, t2, i2]
       end
 
+      def uptime_parser
+        @uptime_parser ||= UptimeParser.new
+      end
+
+      def uptime
+        @cached_data[:uptime] ||= uptime_parser.parse(`uptime`)
+      end
+
       def bsd_load
-        m = `uptime`.split(':')[-1].chomp.gsub(/\s+/, '').split(',')
-        load = m[0].to_f / @cores
+        load = uptime[:load_averages][1] / @cores
         if load > @limits[:load][:critical]
           alert 'load', :critical, load, "1-minute load average/core is #{load}"
         elsif load > @limits[:load][:warning]

--- a/lib/riemann/tools/uptime_parser.y
+++ b/lib/riemann/tools/uptime_parser.y
@@ -1,0 +1,76 @@
+class Riemann::Tools::UptimeParser
+token AM PM UP DAYS HRS MINS SECS USERS LOAD_AVERAGES
+  INTEGER FLOAT
+rule
+  target: time uptime ',' users ',' load_averages { result = { uptime: val[1], users: val[3], load_averages: val[5] } }
+
+  time: INTEGER ':' INTEGER
+      | INTEGER ':' INTEGER AM
+      | INTEGER ':' INTEGER PM
+      | INTEGER ':' INTEGER ':' INTEGER
+
+  uptime: UP uptime_days uptime_hr_min { result = val[1] + val[2] }
+        | UP uptime_days uptime_hr     { result = val[1] + val[2] }
+        | UP uptime_days uptime_min    { result = val[1] + val[2] }
+        | UP uptime_days uptime_sec    { result = val[1] + val[2] }
+        | UP uptime_hr_min             { result = val[1] }
+        | UP uptime_hr                 { result = val[1] }
+        | UP uptime_min                { result = val[1] }
+        | UP uptime_sec                { result = val[1] }
+
+  uptime_days: INTEGER DAYS ',' { result = val[0] * 86400 }
+
+  uptime_hr_min: INTEGER ':' INTEGER { result = val[0] * 3600 + val[2] * 60 }
+
+  uptime_hr: INTEGER HRS { result = val[0] * 3600 }
+
+  uptime_min: INTEGER MINS { result = val[0] * 60 }
+
+  uptime_sec: INTEGER SECS { result = val[0] }
+
+  users: INTEGER USERS
+
+  load_averages: LOAD_AVERAGES FLOAT FLOAT FLOAT         { result = { 1 => val[1], 5 => val[2], 15 => val[3] } }
+               | LOAD_AVERAGES FLOAT ',' FLOAT ',' FLOAT { result = { 1 => val[1], 5 => val[3], 15 => val[5] } }
+end
+
+
+---- header
+
+require 'strscan'
+
+---- inner
+
+  def parse(text)
+    s = StringScanner.new(text)
+    @tokens = []
+
+    until s.eos? do
+      case
+      when s.scan(/\n/)              then # ignore
+      when s.scan(/\s+/)             then # ignore
+
+      when s.scan(/:/)               then @tokens << [':', s.matched]
+      when s.scan(/,/)               then @tokens << [',', s.matched]
+      when s.scan(/\d+[,.]\d+/)      then @tokens << [:FLOAT, s.matched.sub(',', '.').to_f]
+      when s.scan(/\d+/)             then @tokens << [:INTEGER, s.matched.to_i]
+      when s.scan(/AM/)              then @tokens << [:AM, s.matched]
+      when s.scan(/PM/)              then @tokens << [:PM, s.matched]
+      when s.scan(/up/)              then @tokens << [:UP, s.matched]
+      when s.scan(/days?/)           then @tokens << [:DAYS, s.matched]
+      when s.scan(/hrs?/)            then @tokens << [:HRS, s.matched]
+      when s.scan(/mins?/)           then @tokens << [:MINS, s.matched]
+      when s.scan(/secs?/)           then @tokens << [:SECS, s.matched]
+      when s.scan(/users?/)          then @tokens << [:USERS, s.matched]
+      when s.scan(/load averages?:/) then @tokens << [:LOAD_AVERAGES, s.matched]
+      else
+        raise s.rest
+      end
+    end
+
+    do_parse
+  end
+
+  def next_token
+    @tokens.shift
+  end

--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) } -
+      ['lib/riemann/tools/uptime_parser.y'] +
+      ['lib/riemann/tools/uptime_parser.tab.rb']
   end
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -34,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'riemann-client', '~> 1.0'
 
   spec.add_development_dependency 'github_changelog_generator'
+  spec.add_development_dependency 'racc'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'

--- a/spec/riemann/tools/uptime_parser_spec.rb
+++ b/spec/riemann/tools/uptime_parser_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/uptime_parser.tab'
+
+RSpec.describe Riemann::Tools::UptimeParser do
+  {
+    # FreeBSD 13
+    "11:10  up  3:40, 1 user, load averages: 0,25 0,67 0,68\n"              => {
+      uptime: 13_200,
+      users: 1,
+      load_averages: {
+        1  => 0.25,
+        5  => 0.67,
+        15 => 0.68,
+      },
+    },
+    "11:30AM  up 4 hrs, 1 user, load averages: 0.45, 0.53, 0.54\n"          => {
+      uptime: 14_400,
+      users: 1,
+      load_averages: {
+        1  => 0.45,
+        5  => 0.53,
+        15 => 0.54,
+      },
+    },
+    "11:46  up 38 days, 22:21, 2 users, load averages: 1,76 1,24 0,94\n"    => {
+      uptime: 3_363_660,
+      users: 2,
+      load_averages: {
+        1  => 1.76,
+        5  => 1.24,
+        15 => 0.94,
+      },
+    },
+    # CentOS 7
+    " 10:40:21 up 1 day, 18:51,  1 user,  load average: 0,46, 1,45, 2,00\n" => {
+      uptime: 154_260,
+      users: 1,
+      load_averages: {
+        1  => 0.46,
+        5  => 1.45,
+        15 => 2.00,
+      },
+    },
+    " 11:50:17 up 1 day, 20:01,  1 user,  load average: 1.66, 1.69, 1.38\n" => {
+      uptime: 158_460,
+      users: 1,
+      load_averages: {
+        1  => 1.66,
+        5  => 1.69,
+        15 => 1.38,
+      },
+    },
+  }.each do |uptime, expected_data|
+    describe(uptime) do
+      let(:text) { uptime }
+
+      it 'parses correct values' do
+        res = subject.parse(text)
+
+        expect(res).to eq(expected_data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make a new metric with the node uptime available.  The metric is the raw uptime in seconds and the description is a human readable duration.  Critical and Warning thresholds are reversed when compared to other metrics: a value lower that these thresholds indicates a problem. This is intended to get notifications when nodes restart unexpectedly.

The uptime check is not enabled by default and must be explicitly enabled using the `--checks` flag.
