### PR TITLE
Add swap reporting to riemann-health

### DIFF
--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -397,6 +397,8 @@ module Riemann
         value = Float(used) / Integer(blocks)
 
         report_pct :swap, value, 'used'
+      rescue ArgumentError
+        # Ignore
       end
 
       def linux_swap
@@ -411,6 +413,8 @@ module Riemann
           total_size += size.to_f
           total_used += used.to_f
         end
+
+        return if total_size.zero?
 
         value = total_used / total_size
 


### PR DESCRIPTION
Rely on `swapinfo(1)` on all OS excepted from Linux which does not have this UNIX utility but provide an entry in /proc that reports swap usage.

Enable it by default.
