### PR TITLE
Normalize class names

### DIFF
--- a/bin/riemann-freeswitch
+++ b/bin/riemann-freeswitch
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/freeswitch'
 
-Riemann::Tools::FreeSWITCH.run
+Riemann::Tools::Freeswitch.run

--- a/bin/riemann-kvminstance
+++ b/bin/riemann-kvminstance
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/kvm'
 
-Riemann::Tools::KVM.run
+Riemann::Tools::Kvm.run

--- a/lib/riemann/tools/freeswitch.rb
+++ b/lib/riemann/tools/freeswitch.rb
@@ -5,7 +5,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    class FreeSWITCH
+    class Freeswitch
       include Riemann::Tools
 
       opt :calls_warning, 'Calls warning threshold', default: 100

--- a/lib/riemann/tools/kvm.rb
+++ b/lib/riemann/tools/kvm.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    class KVM
+    class Kvm
       include Riemann::Tools
 
       def tick

--- a/tools/riemann-aws/bin/riemann-aws-billing
+++ b/tools/riemann-aws/bin/riemann-aws-billing
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/billing'
 
-Riemann::Tools::AWS::Billing.run
+Riemann::Tools::Aws::Billing.run

--- a/tools/riemann-aws/bin/riemann-aws-rds-status
+++ b/tools/riemann-aws/bin/riemann-aws-rds-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/rds_status'
 
-Riemann::Tools::AWS::RDSStatus.run
+Riemann::Tools::Aws::RdsStatus.run

--- a/tools/riemann-aws/bin/riemann-aws-sqs-status
+++ b/tools/riemann-aws/bin/riemann-aws-sqs-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/sqs_status'
 
-Riemann::Tools::AWS::SQSStatus.run
+Riemann::Tools::Aws::SqsStatus.run

--- a/tools/riemann-aws/bin/riemann-aws-status
+++ b/tools/riemann-aws/bin/riemann-aws-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/status'
 
-Riemann::Tools::AWSStatus.run
+Riemann::Tools::Aws::Status.run

--- a/tools/riemann-aws/bin/riemann-elb-metrics
+++ b/tools/riemann-aws/bin/riemann-elb-metrics
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/elb_metrics'
 
-Riemann::Tools::AWS::ELBMetrics.run
+Riemann::Tools::Aws::ElbMetrics.run

--- a/tools/riemann-aws/bin/riemann-s3-list
+++ b/tools/riemann-aws/bin/riemann-s3-list
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/s3_list'
 
-Riemann::Tools::S3List.run
+Riemann::Tools::Aws::S3List.run

--- a/tools/riemann-aws/bin/riemann-s3-status
+++ b/tools/riemann-aws/bin/riemann-s3-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/s3_status'
 
-Riemann::Tools::AWS::S3Status.run
+Riemann::Tools::Aws::S3Status.run

--- a/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class Billing
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-aws/lib/riemann/tools/aws/elb_metrics.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/elb_metrics.rb
@@ -5,7 +5,7 @@ require 'riemann/tools'
 module Riemann
   module Tools
     module Aws
-      class ELBMetrics
+      class ElbMetrics
         include Riemann::Tools
         require 'fog/aws'
         require 'time'

--- a/tools/riemann-aws/lib/riemann/tools/aws/rds_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/rds_status.rb
@@ -4,8 +4,8 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
-      class RDSStatus
+    module Aws
+      class RdsStatus
         include Riemann::Tools
         require 'fog/aws'
         require 'date'

--- a/tools/riemann-aws/lib/riemann/tools/aws/s3_list.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/s3_list.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class S3List
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-aws/lib/riemann/tools/aws/s3_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/s3_status.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class S3Status
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-aws/lib/riemann/tools/aws/sqs_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/sqs_status.rb
@@ -4,8 +4,8 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
-      class SQSStatus
+    module Aws
+      class SqsStatus
         include Riemann::Tools
         require 'fog/aws'
 

--- a/tools/riemann-aws/lib/riemann/tools/aws/status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/status.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class Status
         include Riemann::Tools
         require 'fog/aws'


### PR DESCRIPTION
Improve the way class and filenames are matched.  The idea is to be able
to automatically require files based on the requested class name using
methods like Rails' String#underscore / String#camelize methods.

This will help with the creation of a generic wrapper abble to load
dynamically extra tools which are unknown to the base riemann-tool gem.

While here, spot and fix a few naming mistakes in previous commit.
