### PR TITLE
Add a wrapper to run multiple tools in a single process

### DIFF
--- a/bin/riemann-freeswitch
+++ b/bin/riemann-freeswitch
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/freeswitch'
 
-Riemann::Tools::FreeSWITCH.run
+Riemann::Tools::Freeswitch.run

--- a/bin/riemann-kvminstance
+++ b/bin/riemann-kvminstance
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/kvm'
 
-Riemann::Tools::KVM.run
+Riemann::Tools::Kvm.run

--- a/bin/riemann-wrapper
+++ b/bin/riemann-wrapper
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Process.setproctitle($PROGRAM_NAME)
+
+def camelize(subject)
+  subject.gsub(%r{(^|[/_])[a-z]}) { |x| x.sub('/', '::').sub('_', '').upcase }
+end
+
+def underscore(subject)
+  subject.split(/(?=[A-Z])/).map(&:downcase).join('_').gsub('::_', '/')
+end
+
+def constantize(subject)
+  Object.const_get(subject)
+end
+
+def read_flags(argv)
+  res = []
+
+  while (arg = argv.shift)
+    break if arg == '--'
+
+    res << arg
+  end
+
+  res
+end
+
+if ARGV.empty?
+  warn <<~USAGE
+    usage: riemann-wrapper [common options] -- tool1 [tool1 options] [-- tool2 [tool2 options] ...]
+
+    Run multiple Riemann tools in a single process.  A single connection to
+    riemann is maintained and shared for all tools, the connection flags should
+    only be passed as common options.
+
+    Examples:
+      1. Run the fd, health and ntp tools with default options:
+
+         riemann-wrapper -- fd -- health -- ntp
+
+      2. Run the fd, health and ntp tools against a remote riemann server using
+         TCP and tagging each event with the name of the tool that produced it:
+
+         riemann-wrapper --host riemann.example.com --tcp -- \\
+                         fd     --tag=fd     -- \\
+                         health --tag=health -- \\
+                         ntp    --tag=ntp
+  USAGE
+  exit 1
+end
+
+argv = ARGV.dup
+
+common_argv = read_flags(argv)
+
+threads = []
+
+while argv.any?
+  tool = argv.shift
+  tool_argv = read_flags(argv)
+
+  require "riemann/tools/#{tool}"
+  tool_class = constantize(camelize("riemann/tools/#{tool}"))
+
+  ARGV.replace(common_argv + tool_argv)
+  instance = tool_class.new
+  # Force evaluation of options.  This rely on ARGV and needs to be done before
+  # we launch multiple threads which compete to read information from there.
+  instance.options
+  threads << Thread.new { instance.run }
+end
+
+threads.each(&:join)

--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -3,7 +3,7 @@
 module Riemann
   module Tools
     require 'optimist'
-    require 'riemann/client'
+    require 'riemann/tools/riemann_client_wrapper'
 
     def self.included(base)
       base.instance_eval do
@@ -72,26 +72,8 @@ module Riemann
       riemann << event
     end
 
-    def new_riemann_client
-      r = Riemann::Client.new(
-        host: options[:host],
-        port: options[:port],
-        timeout: options[:timeout],
-        ssl: options[:tls],
-        key_file: options[:tls_key],
-        cert_file: options[:tls_cert],
-        ca_file: options[:tls_ca_cert],
-        ssl_verify: options[:tls_verify],
-      )
-      if options[:tcp] || options[:tls]
-        r.tcp
-      else
-        r
-      end
-    end
-
     def riemann
-      @riemann ||= new_riemann_client
+      @riemann ||= RiemannClientWrapper.instance.configure(options)
     end
     alias r riemann
 

--- a/lib/riemann/tools/apache_status.rb
+++ b/lib/riemann/tools/apache_status.rb
@@ -68,7 +68,7 @@ module Riemann
       def connection
         response = nil
         begin
-          response = Net::HTTP.get(@uri)
+          response = ::Net::HTTP.get(@uri)
         rescue StandardError => e
           report(
             service: 'httpd health',

--- a/lib/riemann/tools/cloudant.rb
+++ b/lib/riemann/tools/cloudant.rb
@@ -43,10 +43,10 @@ module Riemann
       end
 
       def json
-        http = Net::HTTP.new('cloudant.com', 443)
+        http = ::Net::HTTP.new('cloudant.com', 443)
         http.use_ssl = true
         http.start do |h|
-          get = Net::HTTP::Get.new('/api/load_balancer')
+          get = ::Net::HTTP::Get.new('/api/load_balancer')
           get.basic_auth opts[:cloudant_username], opts[:cloudant_password]
           h.request get
         end

--- a/lib/riemann/tools/consul_health.rb
+++ b/lib/riemann/tools/consul_health.rb
@@ -43,7 +43,7 @@ module Riemann
       end
 
       def get(url)
-        Net::HTTP.get_response(url).body
+        ::Net::HTTP.get_response(url).body
       end
 
       def tick

--- a/lib/riemann/tools/freeswitch.rb
+++ b/lib/riemann/tools/freeswitch.rb
@@ -5,7 +5,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    class FreeSWITCH
+    class Freeswitch
       include Riemann::Tools
 
       opt :calls_warning, 'Calls warning threshold', default: 100

--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -42,10 +42,10 @@ module Riemann
       end
 
       def csv
-        http = Net::HTTP.new(@uri.host, @uri.port)
+        http = ::Net::HTTP.new(@uri.host, @uri.port)
         http.use_ssl = true if @uri.scheme == 'https'
         http.start do |h|
-          get = Net::HTTP::Get.new(@uri.request_uri)
+          get = ::Net::HTTP::Get.new(@uri.request_uri)
           unless @uri.userinfo.nil?
             userinfo = @uri.userinfo.split(':')
             get.basic_auth userinfo[0], userinfo[1]

--- a/lib/riemann/tools/kvm.rb
+++ b/lib/riemann/tools/kvm.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    class KVM
+    class Kvm
       include Riemann::Tools
 
       def tick

--- a/lib/riemann/tools/nginx_status.rb
+++ b/lib/riemann/tools/nginx_status.rb
@@ -53,7 +53,7 @@ module Riemann
       def tick
         response = nil
         begin
-          response = Net::HTTP.get(@uri)
+          response = ::Net::HTTP.get(@uri)
         rescue StandardError => e
           report(
             service: 'nginx health',

--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+require 'riemann/client'
+
+module Riemann
+  module Tools
+    class RiemannClientWrapper
+      include Singleton
+
+      def initialize
+        @client = nil
+      end
+
+      def configure(options)
+        return self unless @client.nil?
+
+        r = Riemann::Client.new(
+          host: options[:host],
+          port: options[:port],
+          timeout: options[:timeout],
+          ssl: options[:tls],
+          key_file: options[:tls_key],
+          cert_file: options[:tls_cert],
+          ca_file: options[:tls_ca_cert],
+          ssl_verify: options[:tls_verify],
+        )
+
+        @client = if options[:tcp] || options[:tls]
+                    r.tcp
+                  else
+                    r
+                  end
+        self
+      end
+
+      def <<(event)
+        @client << event
+      end
+    end
+  end
+end

--- a/tools/riemann-aws/bin/riemann-aws-billing
+++ b/tools/riemann-aws/bin/riemann-aws-billing
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/billing'
 
-Riemann::Tools::AWS::Billing.run
+Riemann::Tools::Aws::Billing.run

--- a/tools/riemann-aws/bin/riemann-aws-rds-status
+++ b/tools/riemann-aws/bin/riemann-aws-rds-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/rds_status'
 
-Riemann::Tools::AWS::RDSStatus.run
+Riemann::Tools::Aws::RdsStatus.run

--- a/tools/riemann-aws/bin/riemann-aws-sqs-status
+++ b/tools/riemann-aws/bin/riemann-aws-sqs-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/sqs_status'
 
-Riemann::Tools::AWS::SQSStatus.run
+Riemann::Tools::Aws::SqsStatus.run

--- a/tools/riemann-aws/bin/riemann-aws-status
+++ b/tools/riemann-aws/bin/riemann-aws-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/status'
 
-Riemann::Tools::AWSStatus.run
+Riemann::Tools::Aws::Status.run

--- a/tools/riemann-aws/bin/riemann-elb-metrics
+++ b/tools/riemann-aws/bin/riemann-elb-metrics
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/elb_metrics'
 
-Riemann::Tools::AWS::ELBMetrics.run
+Riemann::Tools::Aws::ElbMetrics.run

--- a/tools/riemann-aws/bin/riemann-s3-list
+++ b/tools/riemann-aws/bin/riemann-s3-list
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/s3_list'
 
-Riemann::Tools::S3List.run
+Riemann::Tools::Aws::S3List.run

--- a/tools/riemann-aws/bin/riemann-s3-status
+++ b/tools/riemann-aws/bin/riemann-s3-status
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/aws/s3_status'
 
-Riemann::Tools::AWS::S3Status.run
+Riemann::Tools::Aws::S3Status.run

--- a/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class Billing
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-aws/lib/riemann/tools/aws/elb_metrics.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/elb_metrics.rb
@@ -5,7 +5,7 @@ require 'riemann/tools'
 module Riemann
   module Tools
     module Aws
-      class ELBMetrics
+      class ElbMetrics
         include Riemann::Tools
         require 'fog/aws'
         require 'time'

--- a/tools/riemann-aws/lib/riemann/tools/aws/rds_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/rds_status.rb
@@ -4,8 +4,8 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
-      class RDSStatus
+    module Aws
+      class RdsStatus
         include Riemann::Tools
         require 'fog/aws'
         require 'date'

--- a/tools/riemann-aws/lib/riemann/tools/aws/s3_list.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/s3_list.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class S3List
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-aws/lib/riemann/tools/aws/s3_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/s3_status.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class S3Status
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-aws/lib/riemann/tools/aws/sqs_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/sqs_status.rb
@@ -4,8 +4,8 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
-      class SQSStatus
+    module Aws
+      class SqsStatus
         include Riemann::Tools
         require 'fog/aws'
 

--- a/tools/riemann-aws/lib/riemann/tools/aws/status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/status.rb
@@ -4,7 +4,7 @@ require 'riemann/tools'
 
 module Riemann
   module Tools
-    module AWS
+    module Aws
       class Status
         include Riemann::Tools
         require 'fog/aws'

--- a/tools/riemann-riak/lib/riemann/tools/riak.rb
+++ b/tools/riemann-riak/lib/riemann/tools/riak.rb
@@ -34,7 +34,7 @@ module Riemann
         begin
           uri = URI.parse(opts[:riak_host])
           uri.host = opts[:riak_host] if uri.host.nil?
-          http = Net::HTTP.new(uri.host, opts[:stats_port])
+          http = ::Net::HTTP.new(uri.host, opts[:stats_port])
           http.use_ssl = uri.scheme == 'https'
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
           http.start do |h|
@@ -164,7 +164,7 @@ module Riemann
         begin
           uri = URI.parse(opts[:riak_host])
           uri.host = opts[:riak_host] if uri.host.nil?
-          http = Net::HTTP.new(uri.host, opts[:stats_port])
+          http = ::Net::HTTP.new(uri.host, opts[:stats_port])
           http.use_ssl = uri.scheme == 'https'
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
           res = http.start do |h|


### PR DESCRIPTION

A Ruby process has an entry memory cost of about 15 Mb in resident memory
size (RSS).  This is for a process that does nothing and wait for input
on stdin.  When running actual code, this grows with each file loading
and object creation.

Currently, a single riemann-tool process consume about 30 Mb of RSS.
When multiple tools are running simultaneously, these RSS sizes sum up.

Add a generic wrapper tool that allows to run multiple tools from a
single Ruby process, reducing the memory footprint required for the same
workload.

### Profiling

#### Before

```
bundle exec bin/riemann-diskstats &
bundle exec bin/riemann-fd &
bundle exec bin/riemann-health &
bundle exec bin/riemann-net &
bundle exec bin/riemann-ntp &
bundle exec bin/riemann-proc &
```

Relevant ps(1) output:

```
F   UID     PID    PPID PRI  NI    VSZ   RSS WCHAN  STAT TTY        TIME COMMAND
0  1000   28617   28553  20   0  96168 31104 -      S+   pts/13     0:02 bin/riemann-proc
0  1000   28625   28571  20   0  95296 29956 -      S+   pts/14     0:00 bin/riemann-ntp
0  1000   28630   28495  20   0  95684 30712 -      S+   pts/10     0:00 bin/riemann-net
0  1000   28633   25039  20   0  95688 30384 -      S+   pts/9      0:00 bin/riemann-diskstats
0  1000   28635   28535  20   0  94388 29044 -      S+   pts/12     0:00 bin/riemann-fd
0  1000   28642   28517  20   0  96076 30792 -      S+   pts/11     0:00 bin/riemann-health
```

#### After

```
bundle exec bin/riemann-wrapper -- diskstats -- fd -- health -- net  -- ntp -- proc
```

Relevant ps(1) output:

```
F   UID     PID    PPID PRI  NI    VSZ   RSS WCHAN  STAT TTY        TIME COMMAND
0  1000   28955   25039  20   0 500660 31424 -      Sl+  pts/9      0:00 bin/riemann-wrapper
```

This PR include:
* #224 