### PR TITLE
Ignore squashfs from disks usage reporting

### DIFF
--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -16,7 +16,7 @@ module Riemann
       opt :disk_warning, 'Disk warning threshold (fraction of space used)', default: 0.9
       opt :disk_critical, 'Disk critical threshold (fraction of space used)', default: 0.95
       opt :disk_ignorefs, 'A list of filesystem types to ignore',
-          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs tmpfs]
+          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs squashfs tmpfs]
       opt :load_warning, 'Load warning threshold (load average / core)', default: 3.0
       opt :load_critical, 'Load critical threshold (load average / core)', default: 8.0
       opt :memory_warning, 'Memory warning threshold (fraction of RAM)', default: 0.85


### PR DESCRIPTION
squashfs is a compressed read-only filesystem, always reported as full,
so we should exclude it by default.
