### PR TITLE
Add `riemann-zpool` to monitor zpool health

### DIFF
--- a/bin/riemann-zpool
+++ b/bin/riemann-zpool
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Process.setproctitle($PROGRAM_NAME)
+
+require 'riemann/tools/zpool'
+
+Riemann::Tools::Zpool.run

--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+require 'riemann/tools'
+
+module Riemann
+  module Tools
+    class Zpool
+      include Riemann::Tools
+
+      def tick
+        output, status = Open3.capture2e('zpool status -x')
+
+        report(
+          service: 'zpool health',
+          message: output,
+          state: status.success? ? 'ok' : 'critical',
+        )
+      rescue Errno::ENOENT => e
+        report(
+          service: 'zpool health',
+          message: e.message,
+          state: 'critical',
+        )
+      end
+    end
+  end
+end

--- a/spec/riemann/tools/zpool_spec.rb
+++ b/spec/riemann/tools/zpool_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/zpool'
+
+RSpec.describe Riemann::Tools::Zpool do
+  context('#tick') do
+    context 'when pools are healthy' do
+      before do
+        process_status = double
+        allow(process_status).to receive(:success?).and_return(true)
+        allow(Open3).to receive(:capture2e).with('zpool status -x').and_return(["all pools are healthy\n", process_status])
+      end
+
+      it 'reports ok state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'zpool health', message: "all pools are healthy\n", state: 'ok')
+      end
+    end
+
+    context 'when pools are unhealthy' do
+      before do
+        process_status = double
+        allow(process_status).to receive(:success?).and_return(false)
+        allow(Open3).to receive(:capture2e).with('zpool status -x').and_return(['details', process_status])
+      end
+
+      it 'reports critical state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'zpool health', message: 'details', state: 'critical')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce riemann-zpool, a simple wrapper around `zpool status` that
reports the system's pools health.
