### PR TITLE
Add `riemann-md` to monitor Linux RAID/md health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ pkg/
 .DS_Store
 .*.swp
 *.log
-lib/riemann/tools/uptime_parser.tab.rb
+lib/riemann/tools/*_parser.tab.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 ---
 AllCops:
   Exclude:
-    - lib/riemann/tools/uptime_parser.tab.rb
+    - lib/riemann/tools/*_parser.tab.rb
     - vendor/bundle/**/*
 Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -22,8 +22,15 @@ end
 
 task build: :gen_parser
 
-desc 'Generate the uptime parser'
-task gen_parser: 'lib/riemann/tools/uptime_parser.tab.rb'
+desc 'Generate parsers'
+task gen_parser: [
+  'lib/riemann/tools/mdstat_parser.tab.rb',
+  'lib/riemann/tools/uptime_parser.tab.rb',
+]
+
+file 'lib/riemann/tools/mdstat_parser.tab.rb' => 'lib/riemann/tools/mdstat_parser.y' do
+  sh 'racc -S lib/riemann/tools/mdstat_parser.y'
+end
 
 file 'lib/riemann/tools/uptime_parser.tab.rb' => 'lib/riemann/tools/uptime_parser.y' do
   sh 'racc -S lib/riemann/tools/uptime_parser.y'

--- a/bin/riemann-md
+++ b/bin/riemann-md
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Process.setproctitle($PROGRAM_NAME)
+
+require 'riemann/tools/md'
+
+Riemann::Tools::Md.run

--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'riemann/tools'
+require 'riemann/tools/mdstat_parser.tab'
+
+module Riemann
+  module Tools
+    class Md
+      include Riemann::Tools
+
+      def mdstat_parser
+        @mdstat_parser ||= MdstatParser.new
+      end
+
+      def tick
+        status = File.read('/proc/mdstat')
+        res = mdstat_parser.parse(status)
+
+        state = res.values.all? { |value| value =~ /\AU+\z/ } ? 'ok' : 'critical'
+
+        report(
+          service: 'mdstat',
+          message: status,
+          state: state,
+        )
+      rescue Errno::ENOENT => e
+        report(
+          service: 'mdstat',
+          message: e.message,
+          state: 'critical',
+        )
+      end
+    end
+  end
+end

--- a/lib/riemann/tools/mdstat_parser.y
+++ b/lib/riemann/tools/mdstat_parser.y
@@ -1,0 +1,96 @@
+class Riemann::Tools::MdstatParser
+token ALGORITHM BITMAP BLOCKS BYTE_UNIT CHUNK FAILED FINISH FLOAT IDENTIFIER INTEGER LEVEL MIN PAGES PERSONALITIES PERSONALITY PROGRESS RECOVERY SPEED SPEED_UNIT SUPER UNIT UNUSED_DEVICES
+rule
+  target: personalities devices unused_devices { result = val[1] }
+
+  personalities: PERSONALITIES ':' list_of_personalities
+
+  list_of_personalities: list_of_personalities '[' PERSONALITY ']'
+                       |
+
+  devices: devices device { result = val[0].merge(val[1]) }
+         |                { result = {} }
+
+  device: IDENTIFIER ':' IDENTIFIER PERSONALITY list_of_devices INTEGER BLOCKS super level '[' INTEGER '/' INTEGER ']' '[' IDENTIFIER ']' bitmap restore_progress { result = { val[0] => val[15] } }
+
+  list_of_devices: list_of_devices device
+                 | device
+
+  device: IDENTIFIER '[' INTEGER ']' '(' FAILED ')'
+        | IDENTIFIER '[' INTEGER ']'
+
+  super: SUPER FLOAT
+       |
+
+  level: LEVEL INTEGER ',' INTEGER UNIT CHUNK ',' ALGORITHM INTEGER
+       |
+
+  bitmap: BITMAP ':' INTEGER '/' INTEGER PAGES '[' INTEGER BYTE_UNIT ']' ',' INTEGER BYTE_UNIT CHUNK
+        |
+
+  restore_progress: PROGRESS RECOVERY '=' FLOAT '%' '(' INTEGER '/' INTEGER ')' FINISH '=' FLOAT MIN SPEED '=' INTEGER SPEED_UNIT
+                  |
+
+  unused_devices: UNUSED_DEVICES ':' '<' IDENTIFIER '>'
+end
+
+---- header
+
+require 'strscan'
+
+---- inner
+
+  def parse(text)
+    s = StringScanner.new(text)
+    @tokens = []
+
+    until s.eos? do
+      case
+      when s.scan(/\n/)              then # ignore
+      when s.scan(/\s+/)             then # ignore
+
+      when s.scan(/\[=*>.*\]/)       then @tokens << [:PROGRESS, s.matched]
+      when s.scan(/%/)               then @tokens << ['%', s.matched]
+      when s.scan(/,/)               then @tokens << [',', s.matched]
+      when s.scan(/:/)               then @tokens << [':', s.matched]
+      when s.scan(/</)               then @tokens << ['<', s.matched]
+      when s.scan(/=/)               then @tokens << ['=', s.matched]
+      when s.scan(/>/)               then @tokens << ['>', s.matched]
+      when s.scan(/\(/)              then @tokens << ['(', s.matched]
+      when s.scan(/\)/)              then @tokens << [')', s.matched]
+      when s.scan(/\./)              then @tokens << ['.', s.matched]
+      when s.scan(/\//)              then @tokens << ['/', s.matched]
+      when s.scan(/\[/)              then @tokens << ['[', s.matched]
+      when s.scan(/]/)               then @tokens << [']', s.matched]
+      when s.scan(/algorithm/)       then @tokens << [:ALGORITHM, s.matched]
+      when s.scan(/bitmap/)          then @tokens << [:BITMAP, s.matched]
+      when s.scan(/blocks/)          then @tokens << [:BLOCKS, s.matched]
+      when s.scan(/chunk/)           then @tokens << [:CHUNK, s.matched]
+      when s.scan(/finish/)          then @tokens << [:FINISH, s.matched]
+      when s.scan(/level/)           then @tokens << [:LEVEL, s.matched]
+      when s.scan(/min/)             then @tokens << [:MIN, s.matched]
+      when s.scan(/pages/)           then @tokens << [:PAGES, s.matched]
+      when s.scan(/(raid([014-6]|10)|linear|multipath|faulty)\b/) then @tokens << [:PERSONALITY, s.matched]
+      when s.scan(/Personalities/)   then @tokens << [:PERSONALITIES, s.matched]
+      when s.scan(/recovery/)        then @tokens << [:RECOVERY, s.matched]
+      when s.scan(/speed/)           then @tokens << [:SPEED, s.matched]
+      when s.scan(/super/)           then @tokens << [:SUPER, s.matched]
+      when s.scan(/unused devices/)  then @tokens << [:UNUSED_DEVICES, s.matched]
+      when s.scan(/K\/sec/)          then @tokens << [:SPEED_UNIT, s.matched.to_i]
+      when s.scan(/KB/)              then @tokens << [:BYTE_UNIT, s.matched.to_i]
+      when s.scan(/k/)               then @tokens << [:UNIT, s.matched.to_i]
+      when s.scan(/\d+\.\d+/)        then @tokens << [:FLOAT, s.matched.to_i]
+      when s.scan(/\d+/)             then @tokens << [:INTEGER, s.matched.to_i]
+      when s.scan(/F\b/)             then @tokens << [:FAILED, s.matched.to_i]
+      when s.scan(/\w+/)             then @tokens << [:IDENTIFIER, s.matched]
+      else
+        raise s.rest
+      end
+    end
+
+    do_parse
+  end
+
+  def next_token
+    @tokens.shift
+  end

--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -24,8 +24,14 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) } -
-      ['lib/riemann/tools/uptime_parser.y'] +
-      ['lib/riemann/tools/uptime_parser.tab.rb']
+      [
+        'lib/riemann/tools/mdstat_parser.y',
+        'lib/riemann/tools/uptime_parser.y',
+      ] +
+      [
+        'lib/riemann/tools/mdstat_parser.tab.rb',
+        'lib/riemann/tools/uptime_parser.tab.rb',
+      ]
   end
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/fixtures/mdstat/example-1
+++ b/spec/fixtures/mdstat/example-1
@@ -1,0 +1,2 @@
+Personalities : 
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-10
+++ b/spec/fixtures/mdstat/example-10
@@ -1,0 +1,6 @@
+Personalities : [linear] [raid0] [raid1] [raid5] [raid4] [raid6]
+md0 : active raid6 sdf1[0] sde1[1] sdd1[2] sdc1[3] sdb1[4] sda1[5] hdb1[6]
+      1225557760 blocks level 6, 256k chunk, algorithm 2 [7/7] [UUUUUUU]
+      bitmap: 0/234 pages [0KB], 512KB chunk
+
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-11
+++ b/spec/fixtures/mdstat/example-11
@@ -1,0 +1,5 @@
+Personalities : [raid1]
+md1 : active raid1 sde1[6](F) sdg1[1] sdb1[4] sdd1[3] sdc1[2]
+      488383936 blocks [6/4] [_UUUU_]
+
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-2
+++ b/spec/fixtures/mdstat/example-2
@@ -1,0 +1,2 @@
+Personalities : [linear] [multipath] [raid0] [raid1] [raid6] [raid5] [raid4] [raid10] 
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-3
+++ b/spec/fixtures/mdstat/example-3
@@ -1,0 +1,6 @@
+Personalities : [raid1] [linear] [multipath] [raid0] [raid6] [raid5] [raid4] [raid10] 
+md2 : active raid1 sdb2[1] sda2[0]
+      467668992 blocks super 1.2 [2/2] [UU]
+      bitmap: 2/4 pages [8KB], 65536KB chunk
+
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-4
+++ b/spec/fixtures/mdstat/example-4
@@ -1,0 +1,12 @@
+Personalities : [raid1] [linear] [multipath] [raid0] [raid6] [raid5] [raid4] [raid10] 
+md4 : active raid1 sda4[0] sdb4[1]
+      1931457472 blocks [2/2] [UU]
+      bitmap: 0/15 pages [0KB], 65536KB chunk
+
+md2 : active raid1 sda2[0] sdb2[1]
+      523200 blocks [2/2] [UU]
+      
+md3 : active raid1 sdb3[1] sda3[0]
+      20478912 blocks [2/2] [UU]
+      
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-5
+++ b/spec/fixtures/mdstat/example-5
@@ -1,0 +1,11 @@
+Personalities : [raid1] 
+md2 : active raid1 sda3[0] sdb3[2]
+      3902196544 blocks super 1.2 [2/2] [UU]
+      
+md1 : active raid1 sda2[0] sdb2[1]
+      2097088 blocks [5/2] [UU___]
+      
+md0 : active raid1 sda1[0] sdb1[1]
+      2490176 blocks [5/2] [UU___]
+      
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-6
+++ b/spec/fixtures/mdstat/example-6
@@ -1,0 +1,6 @@
+Personalities : [raid1] [raid6] [raid5] [raid4]
+md_d0 : active raid5 sde1[0] sdf1[4] sdb1[5] sdd1[2] sdc1[1]
+      1250241792 blocks super 1.2 level 5, 64k chunk, algorithm 2 [5/5] [UUUUU]
+      bitmap: 0/10 pages [0KB], 16384KB chunk
+
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-7
+++ b/spec/fixtures/mdstat/example-7
@@ -1,0 +1,5 @@
+Personalities : [raid6] [raid5] [raid4]
+md0 : active raid5 sda1[0] sdd1[2] sdb1[1]
+     1465151808 blocks level 5, 64k chunk, algorithm 2 [4/3] [UUU_]
+
+unused devices: <none>

--- a/spec/fixtures/mdstat/example-8
+++ b/spec/fixtures/mdstat/example-8
@@ -1,0 +1,16 @@
+
+
+Personalities : [raid1] [raid6] [raid5] [raid4]
+md1 : active raid1 sdb2[1] sda2[0]
+      136448 blocks [2/2] [UU]
+
+md2 : active raid1 sdb3[1] sda3[0]
+      129596288 blocks [2/2] [UU]
+
+md3 : active raid5 sdl1[9] sdk1[8] sdj1[7] sdi1[6] sdh1[5] sdg1[4] sdf1[3] sde1[2] sdd1[1] sdc1[0]
+      1318680576 blocks level 5, 1024k chunk, algorithm 2 [10/10] [UUUUUUUUUU]
+
+md0 : active raid1 sdb1[1] sda1[0]
+      16787776 blocks [2/2] [UU]
+
+unused devices: <none> 

--- a/spec/fixtures/mdstat/example-9
+++ b/spec/fixtures/mdstat/example-9
@@ -1,0 +1,6 @@
+Personalities : [raid1] [raid6] [raid5] [raid4]
+md127 : active raid5 sdh1[6] sdg1[4] sdf1[3] sde1[2] sdd1[1] sdc1[0]
+      1464725760 blocks level 5, 64k chunk, algorithm 2 [6/5] [UUUUU_]
+      [==>..................]  recovery = 12.6% (37043392/292945152) finish=127.5min speed=33440K/sec
+
+unused devices: <none>

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/md'
+
+RSpec.describe Riemann::Tools::Md do
+  context('#tick') do
+    context 'when all md devices are healthy' do
+      before do
+        allow(File).to receive(:read).with('/proc/mdstat').and_return(File.read('spec/fixtures/mdstat/example-8'))
+      end
+
+      it 'reports ok state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'mdstat', message: //, state: 'ok')
+      end
+    end
+
+    context 'when md devices are unhealthy' do
+      before do
+        allow(File).to receive(:read).with('/proc/mdstat').and_return(File.read('spec/fixtures/mdstat/example-9'))
+      end
+
+      it 'reports critical state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'mdstat', message: //, state: 'critical')
+      end
+    end
+  end
+end

--- a/spec/riemann/tools/mdstat_parser_spec.rb
+++ b/spec/riemann/tools/mdstat_parser_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/mdstat_parser.tab'
+
+RSpec.describe Riemann::Tools::MdstatParser do
+  {
+    'example-1'  => {},
+    'example-2'  => {},
+    'example-3'  => { 'md2' => 'UU' },
+    'example-4'  => { 'md4' => 'UU', 'md2' => 'UU', 'md3' => 'UU' },
+    'example-5'  => { 'md2' => 'UU', 'md1' => 'UU___', 'md0' => 'UU___' },
+    # Examples from https://raid.wiki.kernel.org/index.php/Mdstat
+    'example-6'  => { 'md_d0' => 'UUUUU' },
+    'example-7'  => { 'md0' => 'UUU_' },
+    'example-8'  => { 'md1' => 'UU', 'md2' => 'UU', 'md3' => 'UUUUUUUUUU', 'md0' => 'UU' },
+    'example-9'  => { 'md127' => 'UUUUU_' },
+    'example-10' => { 'md0' => 'UUUUUUU' },
+    'example-11' => { 'md1' => '_UUUU_' },
+  }.each do |config, expected_data|
+    describe(config) do
+      let(:text) { File.read("spec/fixtures/mdstat/#{config}") }
+
+      it 'parses successfuly' do
+        expect { subject.parse(text) }.not_to raise_error
+      end
+
+      it 'parses correct satus' do
+        expect(subject.parse(text)).to eq(expected_data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Linux kernel expose the status of md devices as a file /proc/mdstat
that has quite dynamic content.  Implement a parser to gather the
relevant information and report the system md devices health.
