### PR TITLE
Fix race condition in riemann-wrapper

### DIFF
--- a/bin/riemann-wrapper
+++ b/bin/riemann-wrapper
@@ -69,7 +69,7 @@ while argv.any?
   # Force evaluation of options.  This rely on ARGV and needs to be done before
   # we launch multiple threads which compete to read information from there.
   instance.options
-  threads << Thread.new { instance.run }
+  threads << Thread.new(instance, &:run)
 end
 
 threads.each(&:join)


### PR DESCRIPTION
We need to pass the created tool instance to the thread we create as a
parameter, otherwise the thread get the tool from the parent scope where
the variable can have been replaced by another tools.

Old behavior:

[main] instance <- tool1
[main] start thread1
[main] instance <- tool2
[main] start thread2
[thread1] use instance from main (i.e. tool2)
[thread2] use instance from main (i.e. tool2)

New behavior:

[main] instance <- tool1
[main] start thread1 passing instance from main (i.e. tool1)
[main] instance <- tool2
[main] start thread2 passing instance from main (i.e. tool2)
[thread1] use instance from thread1 (i.e. tool1)
[thread2] use instance from thread2 (i.e. tool2)

Fixes #230
