### PR TITLE
Stop riemann-wrapper if a tool raise an error

### DIFF
--- a/bin/riemann-wrapper
+++ b/bin/riemann-wrapper
@@ -57,6 +57,9 @@ common_argv = read_flags(argv)
 
 threads = []
 
+# Terminate the whole process is some thread fail
+Thread.abort_on_exception = true
+
 while argv.any?
   tool = argv.shift
   tool_argv = read_flags(argv)


### PR DESCRIPTION
The default behavior of Ruby when an exception is raised in a thread is
to not re-raise this exception in the main thread.  When using
`riemann-wrapper` to run multiple tools, if a tool raise an error, that
tool will stop functionning but the other tools will continue to operate
normally, which might lead to unexpectedly expired services hard to
diagnose because the monitoring service is still running.

The tools are expected to gracefuly handle exceptions, but… sh*t
happens.

As a safety, set `Thread.abort_on_exception` to true so that if any
thread is aborted by an exception, the raised exception will be
re-raised in the main thread.  Because we do not catch such exceptions
in `riemann-wrapper`, the process will terminate, and the parent process
(e.g. systemd) will hopefuly re-start it.
