### PR TITLE
Fix detection of degraded zpool

### DIFF
--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -12,10 +12,16 @@ module Riemann
       def tick
         output, status = Open3.capture2e('zpool status -x')
 
+        state = if status.success? && output == "all pools are healthy\n"
+                  'ok'
+                else
+                  'critical'
+                end
+
         report(
           service: 'zpool health',
           message: output,
-          state: status.success? ? 'ok' : 'critical',
+          state: state,
         )
       rescue Errno::ENOENT => e
         report(

--- a/spec/fixtures/zpool/degraded
+++ b/spec/fixtures/zpool/degraded
@@ -1,0 +1,20 @@
+  pool: tank
+ state: DEGRADED
+status: One or more devices could not be used because the label is missing or
+	invalid.  Sufficient replicas exist for the pool to continue
+	functioning in a degraded state.
+action: Replace the device using 'zpool replace'.
+   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-4J
+  scan: scrub repaired 0B in 08:54:08 with 0 errors on Sat Apr  9 21:18:09 2022
+config:
+
+	NAME                     STATE     READ WRITE CKSUM
+	tank                     DEGRADED     0     0     0
+	  mirror-0               DEGRADED     0     0     0
+	    sda                  ONLINE       0     0     0
+	    7902075986954684628  FAULTED      0     0     0  was /dev/sdb1
+	  mirror-1               DEGRADED     0     0     0
+	    6341670446404061421  FAULTED      0     0     0  was /dev/sdc1
+	    sdd                  ONLINE       0     0     0
+
+errors: No known data errors

--- a/spec/fixtures/zpool/healthy
+++ b/spec/fixtures/zpool/healthy
@@ -1,0 +1,1 @@
+all pools are healthy


### PR DESCRIPTION
The exit status from `zpool status -x` cannot be used to detect if a
pool is degraded.  Scan the output instead.
