### PR TITLE
Fix zpool/md informational messages reporting

### DIFF
--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -20,13 +20,13 @@ module Riemann
 
         report(
           service: 'mdstat',
-          message: status,
+          description: status,
           state: state,
         )
       rescue Errno::ENOENT => e
         report(
           service: 'mdstat',
-          message: e.message,
+          description: e.message,
           state: 'critical',
         )
       end

--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -12,10 +12,16 @@ module Riemann
       def tick
         output, status = Open3.capture2e('zpool status -x')
 
+        state = if status.success? && output == "all pools are healthy\n"
+                  'ok'
+                else
+                  'critical'
+                end
+
         report(
           service: 'zpool health',
           message: output,
-          state: status.success? ? 'ok' : 'critical',
+          state: state,
         )
       rescue Errno::ENOENT => e
         report(

--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -20,13 +20,13 @@ module Riemann
 
         report(
           service: 'zpool health',
-          message: output,
+          description: output,
           state: state,
         )
       rescue Errno::ENOENT => e
         report(
           service: 'zpool health',
-          message: e.message,
+          description: e.message,
           state: 'critical',
         )
       end

--- a/spec/fixtures/zpool/degraded
+++ b/spec/fixtures/zpool/degraded
@@ -1,0 +1,20 @@
+  pool: tank
+ state: DEGRADED
+status: One or more devices could not be used because the label is missing or
+	invalid.  Sufficient replicas exist for the pool to continue
+	functioning in a degraded state.
+action: Replace the device using 'zpool replace'.
+   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-4J
+  scan: scrub repaired 0B in 08:54:08 with 0 errors on Sat Apr  9 21:18:09 2022
+config:
+
+	NAME                     STATE     READ WRITE CKSUM
+	tank                     DEGRADED     0     0     0
+	  mirror-0               DEGRADED     0     0     0
+	    sda                  ONLINE       0     0     0
+	    7902075986954684628  FAULTED      0     0     0  was /dev/sdb1
+	  mirror-1               DEGRADED     0     0     0
+	    6341670446404061421  FAULTED      0     0     0  was /dev/sdc1
+	    sdd                  ONLINE       0     0     0
+
+errors: No known data errors

--- a/spec/fixtures/zpool/healthy
+++ b/spec/fixtures/zpool/healthy
@@ -1,0 +1,1 @@
+all pools are healthy

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports ok state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', message: //, state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'ok')
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', message: //, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'critical')
       end
     end
   end

--- a/spec/riemann/tools/zpool_spec.rb
+++ b/spec/riemann/tools/zpool_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Riemann::Tools::Zpool do
       it 'reports ok state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'zpool health', message: "all pools are healthy\n", state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: "all pools are healthy\n", state: 'ok')
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Riemann::Tools::Zpool do
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'zpool health', message: /DEGRADED/, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: /DEGRADED/, state: 'critical')
       end
     end
   end


### PR DESCRIPTION
Informational messages are reported as `description`, not `message`.

This PR also include:
* #237
