### PR TITLE
Improve zpool state reporting

### DIFF
--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -20,13 +20,13 @@ module Riemann
 
         report(
           service: 'mdstat',
-          message: status,
+          description: status,
           state: state,
         )
       rescue Errno::ENOENT => e
         report(
           service: 'mdstat',
-          message: e.message,
+          description: e.message,
           state: 'critical',
         )
       end

--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -12,10 +12,16 @@ module Riemann
       def tick
         output, status = Open3.capture2e('zpool status -x')
 
+        state = if status.success? && output == "all pools are healthy\n"
+                  'ok'
+                else
+                  'critical'
+                end
+
         report(
           service: 'zpool health',
           message: output,
-          state: status.success? ? 'ok' : 'critical',
+          state: state,
         )
       rescue Errno::ENOENT => e
         report(

--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -20,13 +20,13 @@ module Riemann
 
         report(
           service: 'zpool health',
-          message: output,
+          description: output,
           state: state,
         )
       rescue Errno::ENOENT => e
         report(
           service: 'zpool health',
-          message: e.message,
+          description: e.message,
           state: 'critical',
         )
       end

--- a/lib/riemann/tools/zpool.rb
+++ b/lib/riemann/tools/zpool.rb
@@ -12,8 +12,13 @@ module Riemann
       def tick
         output, status = Open3.capture2e('zpool status -x')
 
-        state = if status.success? && output == "all pools are healthy\n"
-                  'ok'
+        state = if status.success?
+                  case output
+                  when "all pools are healthy\n" then 'ok'
+                  when /state: (DEGRADED|FAULTED)/ then 'critical'
+                  else
+                    'warning'
+                  end
                 else
                   'critical'
                 end

--- a/spec/fixtures/zpool/cksum
+++ b/spec/fixtures/zpool/cksum
@@ -1,0 +1,18 @@
+  pool: tank
+ state: ONLINE
+status: One or more devices has experienced an unrecoverable error.  An
+	attempt was made to correct the error.  Applications are unaffected.
+action: Determine if the device needs to be replaced, and clear the errors
+	using 'zpool clear' or replace the device with 'zpool replace'.
+   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-9P
+  scan: resilvered 2.86T in 05:55:33 with 0 errors on Tue Aug 30 07:07:22 2022
+config:
+
+	NAME                      STATE     READ WRITE CKSUM
+	tank                      ONLINE       0     0     0
+	  zfs-9166d2864464be5d    ONLINE       0     0     0
+	  mirror-1                ONLINE       0     0     0
+	    zfs-ce04bfb7c4e33191  ONLINE       0     0     5
+	    zfs-c9ef43242abf7da9  ONLINE       0     0     0
+
+errors: No known data errors

--- a/spec/fixtures/zpool/degraded
+++ b/spec/fixtures/zpool/degraded
@@ -1,0 +1,20 @@
+  pool: tank
+ state: DEGRADED
+status: One or more devices could not be used because the label is missing or
+	invalid.  Sufficient replicas exist for the pool to continue
+	functioning in a degraded state.
+action: Replace the device using 'zpool replace'.
+   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-4J
+  scan: scrub repaired 0B in 08:54:08 with 0 errors on Sat Apr  9 21:18:09 2022
+config:
+
+	NAME                     STATE     READ WRITE CKSUM
+	tank                     DEGRADED     0     0     0
+	  mirror-0               DEGRADED     0     0     0
+	    sda                  ONLINE       0     0     0
+	    7902075986954684628  FAULTED      0     0     0  was /dev/sdb1
+	  mirror-1               DEGRADED     0     0     0
+	    6341670446404061421  FAULTED      0     0     0  was /dev/sdc1
+	    sdd                  ONLINE       0     0     0
+
+errors: No known data errors

--- a/spec/fixtures/zpool/faulted
+++ b/spec/fixtures/zpool/faulted
@@ -1,0 +1,16 @@
+  pool: pool
+ state: FAULTED
+status: One or more of the intent logs could not be read.
+        Waiting for adminstrator intervention to fix the faulted pool.
+action: Either restore the affected device(s) and run 'zpool online',
+        or ignore the intent log records by running 'zpool clear'.
+ scrub: none requested
+config:
+
+        NAME          STATE     READ WRITE CKSUM
+        pool          FAULTED      0     0     0 bad intent log
+          mirror-0    ONLINE       0     0     0
+            c0t1d0    ONLINE       0     0     0
+            c0t4d0    ONLINE       0     0     0
+        logs          FAULTED      0     0     0 bad intent log
+          c0t5d0      UNAVAIL      0     0     0 cannot open

--- a/spec/fixtures/zpool/healthy
+++ b/spec/fixtures/zpool/healthy
@@ -1,0 +1,1 @@
+all pools are healthy

--- a/spec/fixtures/zpool/resilvering
+++ b/spec/fixtures/zpool/resilvering
@@ -1,0 +1,20 @@
+  pool: tank
+ state: ONLINE
+status: One or more devices is currently being resilvered.  The pool will
+	continue to function, possibly in a degraded state.
+action: Wait for the resilver to complete.
+  scan: resilver in progress since Tue Aug 30 07:14:26 2022
+	1.63T scanned at 40.8G/s, 845G issued at 20.6G/s, 9.15T total
+	1.13G resilvered, 9.02% done, 00:06:53 to go
+config:
+
+	NAME                      STATE     READ WRITE CKSUM
+	tank                      ONLINE       0     0     0
+	  mirror-0                ONLINE       0     0     0
+	    zfs-9166d2864464be5d  ONLINE       0     0     0
+	    zfs-d8c2768651c3c537  ONLINE       0     0     0  (resilvering)
+	  mirror-1                ONLINE       0     0     0
+	    zfs-ce04bfb7c4e33191  ONLINE       0     0     0
+	    zfs-c9ef43242abf7da9  ONLINE       0     0     0
+
+errors: No known data errors

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports ok state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', message: //, state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'ok')
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', message: //, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'critical')
       end
     end
   end

--- a/spec/riemann/tools/zpool_spec.rb
+++ b/spec/riemann/tools/zpool_spec.rb
@@ -20,13 +20,43 @@ RSpec.describe Riemann::Tools::Zpool do
       end
     end
 
+    context 'when pools are resilvering' do
+      let(:zpool_output) { 'spec/fixtures/zpool/resilvering' }
+
+      it 'reports warning state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: /state: ONLINE/, state: 'warning')
+      end
+    end
+
     context 'when pools are degraded' do
       let(:zpool_output) { 'spec/fixtures/zpool/degraded' }
 
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'zpool health', description: /DEGRADED/, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: /state: DEGRADED/, state: 'critical')
+      end
+    end
+
+    context 'when pools have checksum errors' do
+      let(:zpool_output) { 'spec/fixtures/zpool/cksum' }
+
+      it 'reports critical state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: /state: ONLINE/, state: 'warning')
+      end
+    end
+
+    context 'when pools are faulted' do
+      let(:zpool_output) { 'spec/fixtures/zpool/faulted' }
+
+      it 'reports critical state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: /state: FAULTED/, state: 'critical')
       end
     end
   end

--- a/spec/riemann/tools/zpool_spec.rb
+++ b/spec/riemann/tools/zpool_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Riemann::Tools::Zpool do
       it 'reports ok state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'zpool health', message: "all pools are healthy\n", state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: "all pools are healthy\n", state: 'ok')
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Riemann::Tools::Zpool do
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'zpool health', message: /DEGRADED/, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'zpool health', description: /DEGRADED/, state: 'critical')
       end
     end
   end


### PR DESCRIPTION
When a FAULTED or DEGRADED zpool is back ONLINE and resilvering after changing disks, it is still reported in `zpool status -x` output until the pool is healthy again.  Such a state should probably not be reported as critical but it is still something to keep an eye on, so report all the known-bad states as `critial` as before but report this resilvering status (and also unknown statuses that might be introduced in the future) as `warning` only.

This PR also include:
* #237
* #238
