### PR TITLE
Fix parsing of mdstat when device is being checked

### DIFF
--- a/spec/fixtures/mdstat/example-12
+++ b/spec/fixtures/mdstat/example-12
@@ -1,0 +1,10 @@
+Personalities : [raid1] [linear] [multipath] [raid0] [raid6] [raid5] [raid4] [raid10] 
+md3 : active raid1 sdb3[0] sda3[1]
+      463604672 blocks [2/2] [UU]
+      [===>.................]  check = 19.8% (91876096/463604672) finish=30.0min speed=206312K/sec
+      bitmap: 4/4 pages [16KB], 65536KB chunk
+
+md2 : active raid1 sdb2[0] sda2[1]
+      523200 blocks [2/2] [UU]
+      
+unused devices: <none>

--- a/spec/riemann/tools/mdstat_parser_spec.rb
+++ b/spec/riemann/tools/mdstat_parser_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Riemann::Tools::MdstatParser do
     'example-9'  => { 'md127' => 'UUUUU_' },
     'example-10' => { 'md0' => 'UUUUUUU' },
     'example-11' => { 'md1' => '_UUUU_' },
+    'example-12' => { 'md2' => 'UU', 'md3' => 'UU' },
   }.each do |config, expected_data|
     describe(config) do
       let(:text) { File.read("spec/fixtures/mdstat/#{config}") }


### PR DESCRIPTION
The content of /dev/mdstat when a device is being checked looks like the
one of a device being recovering, and [a few more values can be
reported](https://github.com/torvalds/linux/blob/7726d4c3e60bfe206738894267414a5f10510f1a/drivers/md/md.c#L8089-L8098).

This information is reported *before* the bitmap when present, and not
after as the parser expected (the examples from the documentation did
not mix bitmaps and recovery, but the weekly check from Debian broke the
`mdstat` reporting during the check).

Fix the ordering and allow the new values to be parsed.  Add an example
from a live output of one of our nodes to ensure we don't break this in
the future.
