### PR TITLE
Improve error reporting on parse error

### DIFF
--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -23,6 +23,12 @@ module Riemann
           description: status,
           state: state,
         )
+      rescue Racc::ParseError => e
+        report(
+          service: 'mdstat',
+          description: "Error parsing mdstat: #{e.message}",
+          state: 'critical',
+        )
       rescue Errno::ENOENT => e
         report(
           service: 'mdstat',

--- a/lib/riemann/tools/mdstat_parser.y
+++ b/lib/riemann/tools/mdstat_parser.y
@@ -85,12 +85,12 @@ require 'riemann/tools/utils'
       when s.scan(/speed/)           then s.push_token(:SPEED)
       when s.scan(/super/)           then s.push_token(:SUPER)
       when s.scan(/unused devices/)  then s.push_token(:UNUSED_DEVICES)
-      when s.scan(/K\/sec/)          then s.push_token(:SPEED_UNIT, s.matched.to_i)
-      when s.scan(/KB/)              then s.push_token(:BYTE_UNIT, s.matched.to_i)
-      when s.scan(/k/)               then s.push_token(:UNIT, s.matched.to_i)
-      when s.scan(/\d+\.\d+/)        then s.push_token(:FLOAT, s.matched.to_i)
+      when s.scan(/K\/sec/)          then s.push_token(:SPEED_UNIT)
+      when s.scan(/KB/)              then s.push_token(:BYTE_UNIT)
+      when s.scan(/k/)               then s.push_token(:UNIT)
+      when s.scan(/\d+\.\d+/)        then s.push_token(:FLOAT, s.matched.to_f)
       when s.scan(/\d+/)             then s.push_token(:INTEGER, s.matched.to_i)
-      when s.scan(/F\b/)             then s.push_token(:FAILED, s.matched.to_i)
+      when s.scan(/F\b/)             then s.push_token(:FAILED)
       when s.scan(/\w+/)             then s.push_token(:IDENTIFIER)
       else
         s.unexpected_token

--- a/lib/riemann/tools/uptime_parser.y
+++ b/lib/riemann/tools/uptime_parser.y
@@ -18,20 +18,20 @@ rule
         | UP uptime_min                { result = val[1] }
         | UP uptime_sec                { result = val[1] }
 
-  uptime_days: INTEGER DAYS ',' { result = val[0] * 86400 }
+  uptime_days: INTEGER DAYS ',' { result = val[0][:value] * 86400 }
 
-  uptime_hr_min: INTEGER ':' INTEGER { result = val[0] * 3600 + val[2] * 60 }
+  uptime_hr_min: INTEGER ':' INTEGER { result = val[0][:value] * 3600 + val[2][:value] * 60 }
 
-  uptime_hr: INTEGER HRS { result = val[0] * 3600 }
+  uptime_hr: INTEGER HRS { result = val[0][:value] * 3600 }
 
-  uptime_min: INTEGER MINS { result = val[0] * 60 }
+  uptime_min: INTEGER MINS { result = val[0][:value] * 60 }
 
-  uptime_sec: INTEGER SECS { result = val[0] }
+  uptime_sec: INTEGER SECS { result = val[0][:value] }
 
-  users: INTEGER USERS
+  users: INTEGER USERS { result = val[0][:value] }
 
-  load_averages: LOAD_AVERAGES FLOAT FLOAT FLOAT         { result = { 1 => val[1], 5 => val[2], 15 => val[3] } }
-               | LOAD_AVERAGES FLOAT ',' FLOAT ',' FLOAT { result = { 1 => val[1], 5 => val[3], 15 => val[5] } }
+  load_averages: LOAD_AVERAGES FLOAT FLOAT FLOAT         { result = { 1 => val[1][:value], 5 => val[2][:value], 15 => val[3][:value] } }
+               | LOAD_AVERAGES FLOAT ',' FLOAT ',' FLOAT { result = { 1 => val[1][:value], 5 => val[3][:value], 15 => val[5][:value] } }
 end
 
 
@@ -39,38 +39,45 @@ end
 
 require 'strscan'
 
+require 'riemann/tools/utils'
+
 ---- inner
 
   def parse(text)
-    s = StringScanner.new(text)
-    @tokens = []
+    s = Utils::StringTokenizer.new(text)
 
     until s.eos? do
       case
-      when s.scan(/\n/)              then # ignore
-      when s.scan(/\s+/)             then # ignore
+      when s.scan(/\n/)              then s.push_token(nil)
+      when s.scan(/\s+/)             then s.push_token(nil)
 
-      when s.scan(/:/)               then @tokens << [':', s.matched]
-      when s.scan(/,/)               then @tokens << [',', s.matched]
-      when s.scan(/\d+[,.]\d+/)      then @tokens << [:FLOAT, s.matched.sub(',', '.').to_f]
-      when s.scan(/\d+/)             then @tokens << [:INTEGER, s.matched.to_i]
-      when s.scan(/AM/)              then @tokens << [:AM, s.matched]
-      when s.scan(/PM/)              then @tokens << [:PM, s.matched]
-      when s.scan(/up/)              then @tokens << [:UP, s.matched]
-      when s.scan(/days?/)           then @tokens << [:DAYS, s.matched]
-      when s.scan(/hrs?/)            then @tokens << [:HRS, s.matched]
-      when s.scan(/mins?/)           then @tokens << [:MINS, s.matched]
-      when s.scan(/secs?/)           then @tokens << [:SECS, s.matched]
-      when s.scan(/users?/)          then @tokens << [:USERS, s.matched]
-      when s.scan(/load averages?:/) then @tokens << [:LOAD_AVERAGES, s.matched]
+      when s.scan(/:/)               then s.push_token(':')
+      when s.scan(/,/)               then s.push_token(',')
+      when s.scan(/\d+[,.]\d+/)      then s.push_token(:FLOAT, s.matched.sub(',', '.').to_f)
+      when s.scan(/\d+/)             then s.push_token(:INTEGER, s.matched.to_i)
+      when s.scan(/AM/)              then s.push_token(:AM)
+      when s.scan(/PM/)              then s.push_token(:PM)
+      when s.scan(/up/)              then s.push_token(:UP)
+      when s.scan(/days?/)           then s.push_token(:DAYS)
+      when s.scan(/hrs?/)            then s.push_token(:HRS)
+      when s.scan(/mins?/)           then s.push_token(:MINS)
+      when s.scan(/secs?/)           then s.push_token(:SECS)
+      when s.scan(/users?/)          then s.push_token(:USERS)
+      when s.scan(/load averages?:/) then s.push_token(:LOAD_AVERAGES)
       else
-        raise s.rest
+        raise s.unexpected_token
       end
     end
+
+    @tokens = s.tokens
 
     do_parse
   end
 
   def next_token
     @tokens.shift
+  end
+
+  def on_error(error_token_id, error_value, value_stack)
+    raise(Racc::ParseError, "parse error on value \"#{error_value[:value]}\" (#{token_to_str(error_token_id)}) on line #{error_value[:lineno]}:\n#{error_value[:line]}\n#{' ' * error_value[:pos]}^#{'~' * (error_value[:value].to_s.length - 1)}")
   end

--- a/lib/riemann/tools/utils.rb
+++ b/lib/riemann/tools/utils.rb
@@ -3,6 +3,54 @@
 module Riemann
   module Tools
     module Utils # :nodoc:
+      class StringTokenizer
+        attr_reader :tokens
+
+        def initialize(text)
+          @scanner = StringScanner.new(text)
+
+          @lineno = 1
+          @pos = 0
+          @line = next_line
+          @tokens = []
+        end
+
+        def scan(expression)
+          @scanner.scan(expression)
+        end
+
+        def eos?
+          @scanner.eos?
+        end
+
+        def matched
+          @scanner.matched
+        end
+
+        def next_line
+          (@scanner.check_until(/\n/) || @scanner.rest).chomp
+        end
+
+        def push_token(token, value = nil)
+          value ||= @scanner.matched
+
+          if value == "\n"
+            @lineno += 1
+            @line = next_line
+            @pos = pos = 0
+          else
+            pos = @pos
+            @pos += @scanner.matched.length
+          end
+
+          @tokens << [token, { value: value, line: @line, lineno: @lineno, pos: pos }] if token
+        end
+
+        def unexpected_token
+          raise(Racc::ParseError, "unexpected data on line #{@lineno}:\n#{@line}\n#{' ' * @pos}^#{'~' * (@line.length - @pos - 1)}")
+        end
+      end
+
       def reverse_numeric_sort_with_header(data, header: 1, count: 10)
         lines = data.chomp.split("\n")
         header = lines.shift(header)

--- a/lib/riemann/tools/utils.rb
+++ b/lib/riemann/tools/utils.rb
@@ -47,7 +47,7 @@ module Riemann
         end
 
         def unexpected_token
-          raise(Racc::ParseError, "unexpected data on line #{@lineno}:\n#{@line}\n#{' ' * @pos}^#{'~' * (@line.length - @pos - 1)}")
+          raise(Racc::ParseError, "unexpected data on line #{@lineno}:\n#{@line}\n#{' ' * @pos}^")
         end
       end
 

--- a/spec/riemann/tools/health_spec.rb
+++ b/spec/riemann/tools/health_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Riemann::Tools::Health do
         expect(subject).to have_received(:report).with(service: 'uptime', description: <<~DESCRIPTION.chomp, state: 'critical')
           Error parsing uptime: unexpected data on line 1:
           10:27:42 up 20:05,  1 user,  load average: 0.79, 0.50, 0.44 [IO: 0.15, 0.12, 0.08 CPU: 0.64, 0.38, 0.35]
-                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                                      ^
         DESCRIPTION
       end
     end

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Riemann::Tools::Md do
         expect(subject).to have_received(:report).with(service: 'mdstat', description: <<~DESCRIPTION.chomp, state: 'critical')
           Error parsing mdstat: unexpected data on line 2:
           md2 : active raid1+ sda3[0] sdb3[2]
-                            ^~~~~~~~~~~~~~~~~
+                            ^
         DESCRIPTION
       end
     end

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -27,5 +27,62 @@ RSpec.describe Riemann::Tools::Md do
         expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'critical')
       end
     end
+
+    context 'when given unexpected data' do
+      before do
+        allow(File).to receive(:read).with('/proc/mdstat').and_return(<<~DOCUMENT)
+          Personalities : [raid1]
+          md2 : active raid1 sda3[0] sdb3[2]
+                3902196544 blocks super 1.2 [2/2] [UU]
+                42 splines reticulated
+
+          md1 : active raid1 sda2[0] sdb2[1]
+                2097088 blocks [5/2] [UU___]
+
+          md0 : active raid1 sda1[0] sdb1[1]
+                2490176 blocks [5/2] [UU___]
+
+          unused devices: <none>
+        DOCUMENT
+      end
+
+      it 'reports critical state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'mdstat', description: <<~DESCRIPTION.chomp, state: 'critical')
+          Error parsing mdstat: parse error on value "42" (INTEGER) on line 4:
+                42 splines reticulated
+                ^~
+        DESCRIPTION
+      end
+    end
+
+    context 'when given malformed data' do
+      before do
+        allow(File).to receive(:read).with('/proc/mdstat').and_return(<<~DOCUMENT)
+          Personalities : [raid1]
+          md2 : active raid1+ sda3[0] sdb3[2]
+                3902196544 blocks super 1.2 [2/2] [UU]
+
+          md1 : active raid1+ sda2[0] sdb2[1]
+                2097088 blocks [5/2] [UU___]
+
+          md0 : active raid1+ sda1[0] sdb1[1]
+                2490176 blocks [5/2] [UU___]
+
+          unused devices: <none>
+        DOCUMENT
+      end
+
+      it 'reports critical state' do
+        allow(subject).to receive(:report)
+        subject.tick
+        expect(subject).to have_received(:report).with(service: 'mdstat', description: <<~DESCRIPTION.chomp, state: 'critical')
+          Error parsing mdstat: unexpected data on line 2:
+          md2 : active raid1+ sda3[0] sdb3[2]
+                            ^~~~~~~~~~~~~~~~~
+        DESCRIPTION
+      end
+    end
   end
 end


### PR DESCRIPTION
When a parser cannot parse a document, it raised a Racc::ParseError if
the document was malformed or a RuntimeError if the content was not
processable.  In any case, the exception was not explicitely catched and
was logged to stderr.  If events where previously reported they would
eventualy expire, otherwise nothing would make the failure visible on the
riemann side.

Improve exception handling by formatting a custom error messages which
show the line of the failure in the parsed document and sending it as a
critical event to riemann.
