### PR TITLE
Fix `riemann-haproxy` HTTP response processing

### DIFF
--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -44,7 +44,7 @@ module Riemann
       def csv
         http = ::Net::HTTP.new(@uri.host, @uri.port)
         http.use_ssl = true if @uri.scheme == 'https'
-        http.start do |h|
+        res = http.start do |h|
           get = ::Net::HTTP::Get.new(@uri.request_uri)
           unless @uri.userinfo.nil?
             userinfo = @uri.userinfo.split(':')
@@ -52,8 +52,9 @@ module Riemann
           end
           h.request get
         end
-        CSV.parse(http.body.split('# ')[1], { headers: true })
+        CSV.parse(res.body.split('# ')[1], { headers: true })
       end
     end
   end
 end
+

--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -57,4 +57,3 @@ module Riemann
     end
   end
 end
-


### PR DESCRIPTION
Fixes the following error returned by `riemann-haproxy`:

```
NoMethodError undefined method `body' for #<Net::HTTP haproxy_host:8404 open=false>
```

