### PR TITLE
Fix `riemann-health` detection of `df` header

### DIFF
--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -387,9 +387,8 @@ module Riemann
       end
 
       def disk
-        df.split(/\n/).each do |r|
+        df.lines[1..].each do |r|
           f = r.split(/\s+/)
-          next if f[0] == 'Filesystem'
 
           # Calculate capacity
           used = f[2].to_i

--- a/spec/riemann/tools/health_spec.rb
+++ b/spec/riemann/tools/health_spec.rb
@@ -46,6 +46,24 @@ RSpec.describe Riemann::Tools::Health do
       expect(subject).to have_received(:alert).with('disk /var/log', :ok, 2.0545157787749945e-05, '0% used')
       expect(subject).to have_received(:alert).with('disk /usr/home/romain/Medias', :ok, 0.39906518922242257, '40% used')
     end
+
+    context 'with a foreign locale' do
+      before do
+        allow(subject).to receive(:df).and_return(<<~OUTPUT)
+          Sys. de fichiers blocs de 1024  Utilisé Disponible Capacité Monté sur
+          /dev/md1              20026172 11898676    7087168      63% /
+          /dev/md2              94569252 19758048   69984228      23% /home
+        OUTPUT
+      end
+
+      it 'reports all zfs filesystems' do
+        allow(subject).to receive(:alert).with('disk /', :ok, 0.6267130394624543, '63% used')
+        allow(subject).to receive(:alert).with('disk /home', :ok, 0.22016432923987797, '23% used')
+        subject.disk
+        expect(subject).to have_received(:alert).with('disk /', :ok, 0.6267130394624543, '63% used')
+        expect(subject).to have_received(:alert).with('disk /home', :ok, 0.22016432923987797, '23% used')
+      end
+    end
   end
 
   context '#bsd_swap' do


### PR DESCRIPTION
GNU df(1) can localize its output.  This breaks riemann-health header
detection.

Because the header is always on the first line, we can ignore this line and do
not care about its content.

Add a unit test that shows the problem so that we can fix
it and not break it in the future.
