### PR TITLE
Add `riemann-http-check` to monitor HTTP(S) resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -32,7 +32,7 @@ jobs:
           - 3.0
           - 3.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,7 @@ ship with the `riemann-tools` gem, including:
 * riemann-kvminstance - Monitor KVM instances.
 * riemann-ntp - Monitor NTP.
 * riemann-portcheck - Monitor open TCP ports.
+* riemann-http-check - Monitor reachability of HTTP(S) resources.
 
 Also contained in the repository are a number of stand-alone monitoring
 tools, which are shipped as separate gems.

--- a/bin/riemann-http-check
+++ b/bin/riemann-http-check
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Process.setproctitle($PROGRAM_NAME)
+
+require 'riemann/tools/http_check'
+
+Riemann::Tools::HttpCheck.run

--- a/bin/riemann-http-check
+++ b/bin/riemann-http-check
@@ -5,4 +5,6 @@ Process.setproctitle($PROGRAM_NAME)
 
 require 'riemann/tools/http_check'
 
+raise("Ruby #{Riemann::Tools::HttpCheck::REQUIRED_RUBY_VERSION} or better is required for using riemann-http-check") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(Riemann::Tools::HttpCheck::REQUIRED_RUBY_VERSION)
+
 Riemann::Tools::HttpCheck.run

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'resolv'
+require 'socket'
+
+require 'riemann/tools'
+
+# Test for HTTP requests
+module Riemann
+  module Tools
+    class HttpCheck
+      include Riemann::Tools
+
+      opt :uri, 'URI to fetch', short: :none, type: :strings, default: ['http://localhost']
+      opt :response, 'Expected response codes', short: :none, type: :strings, default: [
+        '200', # OK
+        '301', # Moved Permanently
+        '401', # Unauthorized
+      ]
+      opt :connection_latency_warning, 'Lattency warning threshold', short: :none, default: 0.1
+      opt :connection_latency_critical, 'Lattency critical threshold', short: :none, default: 0.25
+      opt :response_latency_warning, 'Lattency warning threshold', short: :none, default: 0.5
+      opt :response_latency_critical, 'Lattency critical threshold', short: :none, default: 1.0
+      opt :http_timeout, 'Timeout (in seconds) for HTTP requests', short: :none, default: 5.0
+      opt :checks, 'A list of checks to run.', short: :none, type: :strings, default: %w[consistency connection-latency response-code response-latency]
+
+      def tick
+        opts[:uri].each do |uri|
+          test_uri(uri)
+        end
+      end
+
+      def test_uri(uri)
+        uri = URI(uri)
+
+        request = ::Net::HTTP::Get.new(uri)
+        request.basic_auth(uri.user, uri.password)
+
+        responses = []
+
+        with_each_address(uri.host) do |address|
+          responses << test_uri_address(uri, address, request)
+        end
+
+        responses.compact!
+
+        return unless opts[:checks].include?('consistency')
+
+        raise StandardError, "Could not get any response from #{uri.host}" unless responses.any?
+
+        uniq_code = responses.map(&:code).uniq
+        uniq_body = responses.map(&:body).uniq
+
+        issues = []
+        issues << "#{uniq_code.count} different response code" unless uniq_code.one?
+        issues << "#{uniq_body.count} different response body" unless uniq_body.one?
+
+        if issues.none?
+          state = 'ok'
+          description = "consistent response on all #{responses.count} endpoints"
+        else
+          state = 'critical'
+          description = "#{issues.join(' and ')} on #{responses.count} endpoints"
+        end
+
+        report(
+          service: service(uri, 'consistency'),
+          state: state,
+          description: description,
+          hostname: uri.host,
+          port: uri.port,
+        )
+      rescue StandardError => e
+        report(
+          service: service(uri, 'consistency'),
+          state: 'critical',
+          description: e.message,
+          hostname: uri.host,
+          port: uri.port,
+        )
+      end
+
+      def test_uri_address(uri, address, request)
+        response = nil
+
+        start = Time.now
+        connected = nil
+        done = nil
+
+        http = nil
+        begin
+          Timeout.timeout(opts[:http_timeout]) do
+            http = ::Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', verify_mode: OpenSSL::SSL::VERIFY_NONE, ipaddr: address)
+            connected = Time.now
+            response = http.request(request)
+          end
+        rescue Timeout::Error
+          # Ignore
+        else
+          done = Time.now
+        ensure
+          http&.finish
+        end
+
+        report_http_endpoint_response_code(http, uri, response) if opts[:checks].include?('response-code')
+        report_http_endpoint_latency(http, uri, 'connection', start, connected) if opts[:checks].include?('connection-latency')
+        report_http_endpoint_latency(http, uri, 'response', start, done) if opts[:checks].include?('response-latency')
+
+        response
+      rescue StandardError
+        # Ignore this address
+        nil
+      end
+
+      def with_each_address(host, &block)
+        addresses = Resolv::DNS.new.getaddresses(host)
+        if addresses.empty?
+          host = host[1...-1] if host[0] == '[' && host[-1] == ']'
+          addresses << IPAddr.new(host)
+        end
+
+        addresses.each do |address|
+          block.call(address.to_s)
+        end
+      end
+
+      def report_http_endpoint_response_code(http, uri, response)
+        return unless response
+
+        report(
+          {
+            state: response_code_state(response.code),
+            metric: response.code.to_i,
+            description: "#{response.code} #{response.message}",
+          }.merge(endpoint_report(http, uri, 'response code')),
+        )
+      end
+
+      def response_code_state(code)
+        opts[:response].include?(code) ? 'ok' : 'critical'
+      end
+
+      def report_http_endpoint_latency(http, uri, latency, start, stop)
+        if stop
+          metric = stop - start
+          report(
+            {
+              state: latency_state(latency, metric),
+              metric: metric,
+              description: format('%.3f ms', metric * 1000),
+            }.merge(endpoint_report(http, uri, "#{latency} latency")),
+          )
+        else
+          report(
+            {
+              state: 'critical',
+              description: 'timeout',
+            }.merge(endpoint_report(http, uri, "#{latency} latency")),
+          )
+        end
+      end
+
+      def latency_state(name, latency)
+        if latency > opts["#{name}_latency_critical".to_sym]
+          'critical'
+        elsif latency > opts["#{name}_latency_warning".to_sym]
+          'warning'
+        else
+          'ok'
+        end
+      end
+
+      def endpoint_report(http, uri, service)
+        {
+          service: endpoint_service(http, uri, service),
+          hostname: uri.host,
+          address: http.ipaddr,
+          port: uri.port,
+        }
+      end
+
+      def endpoint_service(http, uri, service)
+        "get #{redact_uri(uri)} #{endpoint_name(IPAddr.new(http.ipaddr), http.port)} #{service}"
+      end
+
+      def service(uri, service)
+        "get #{redact_uri(uri)} #{service}"
+      end
+
+      def redact_uri(uri)
+        reported_uri = uri.dup
+        reported_uri.password = '**redacted**' if reported_uri.password
+        reported_uri
+      end
+
+      def endpoint_name(address, port)
+        if address.ipv6?
+          "[#{address}]:#{port}"
+        else
+          "#{address}:#{port}"
+        end
+      end
+    end
+  end
+end

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -10,6 +10,8 @@ require 'riemann/tools'
 module Riemann
   module Tools
     class HttpCheck
+      REQUIRED_RUBY_VERSION = '2.7.0'
+
       include Riemann::Tools
 
       opt :uri, 'URI to fetch', short: :none, type: :strings, default: ['http://localhost']

--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -48,4 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rake'
   spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'sinatra'
+  spec.add_development_dependency 'webrick'
 end

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -52,7 +52,7 @@ class TestWebserver < Sinatra::Base
   end
 end
 
-RSpec.describe Riemann::Tools::HttpCheck do
+RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(Riemann::Tools::HttpCheck::REQUIRED_RUBY_VERSION) do
   describe '#endpoint_name' do
     subject { described_class.new.endpoint_name(address, port) }
     let(:port) { 443 }

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'rack/handler/webrick'
+require 'sinatra/base'
+require 'webrick'
+require 'webrick/https'
+
+require 'riemann/tools/http_check'
+
+TEST_WEBSERVER_PORT = 65_391
+
+class TestWebserver < Sinatra::Base
+  def authorized?
+    @auth ||= Rack::Auth::Basic::Request.new(request.env)
+    @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == %w[admin secret]
+  end
+
+  def protected!
+    return if authorized?
+
+    response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+    throw(:halt, [401, "Oops... we need your login name & password\n"])
+  end
+
+  get '/' do
+    'ok'
+  end
+
+  get '/protected' do
+    protected!
+    'ok'
+  end
+
+  get '/slow' do
+    sleep(0.5)
+    'ok'
+  end
+
+  get '/sloww' do
+    sleep(1)
+    'ok'
+  end
+
+  get '/slowww' do
+    sleep(10)
+    'ok'
+  end
+
+  get '/rand' do
+    SecureRandom.hex(16)
+  end
+end
+
+RSpec.describe Riemann::Tools::HttpCheck do
+  describe '#endpoint_name' do
+    subject { described_class.new.endpoint_name(address, port) }
+    let(:port) { 443 }
+
+    context 'when using an IPv4 address' do
+      let(:address) { IPAddr.new('127.0.0.1') }
+
+      it { is_expected.to eq('127.0.0.1:443') }
+    end
+
+    context 'when using an IPv6 address' do
+      let(:address) { IPAddr.new('::1') }
+
+      it { is_expected.to eq('[::1]:443') }
+    end
+  end
+
+  describe '#test_uri' do
+    before do
+      subject.options[:http_timeout] = http_timeout
+      allow(subject).to receive(:report)
+      allow(subject).to receive(:with_each_address).with('example.com').and_yield('::1').and_yield('127.0.0.1')
+      allow(subject).to receive(:with_each_address).with('127.0.0.1').and_call_original
+      allow(subject).to receive(:with_each_address).with('[::1]').and_call_original
+      allow(subject).to receive(:with_each_address).with('invalid.example.com')
+      subject.test_uri(uri)
+    end
+
+    let(:http_timeout) { 2.0 }
+
+    context 'when using unencrypted http' do
+      before(:all) do
+        server_options = {
+          Port: TEST_WEBSERVER_PORT,
+          StartCallback: -> { @started = true },
+          AccessLog: [],
+          Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
+        }
+        @server = WEBrick::HTTPServer.new(server_options)
+        @server.mount('/', Rack::Handler::WEBrick, TestWebserver)
+        @started = false
+        Thread.new { @server.start }
+        Timeout.timeout(1) { sleep(0.1) until @started }
+      end
+
+      after(:all) do
+        @server&.shutdown
+      end
+
+      let(:reported_uri) { uri }
+
+      context 'with a fast uri' do
+        let(:uri) { "http://example.com:#{TEST_WEBSERVER_PORT}/" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+      end
+
+      context 'with a slow uri' do
+        let(:uri) { "http://example.com:#{TEST_WEBSERVER_PORT}/slow" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slow [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'warning' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slow 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'warning' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slow consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+      end
+
+      context 'with a very slow uri' do
+        let(:uri) { "http://example.com:#{TEST_WEBSERVER_PORT}/sloww" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/sloww [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'critical' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/sloww 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'critical' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/sloww consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+      end
+
+      context 'with a too slow uri' do
+        let(:uri) { "http://example.com:#{TEST_WEBSERVER_PORT}/slowww" }
+        let(:http_timeout) { 0.1 }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slowww [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'critical', description: 'timeout' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slowww 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'critical', description: 'timeout' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slowww consistency", state: 'critical', description: 'Could not get any response from example.com' })) }
+      end
+
+      context 'with inconsistent responses' do
+        let(:uri) { "http://example.com:#{TEST_WEBSERVER_PORT}/rand" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand consistency", state: 'critical', description: '2 different response body on 2 endpoints' })) }
+      end
+
+      context 'with basic authentication and a good password' do
+        let(:uri) { "http://admin:secret@example.com:#{TEST_WEBSERVER_PORT}/protected" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+      end
+
+      context 'with basic authentication and a wrong password' do
+        let(:uri) { "http://admin:wrong-password@example.com:#{TEST_WEBSERVER_PORT}/protected" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 401, state: 'ok', description: '401 Unauthorized' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 401, state: 'ok', description: '401 Unauthorized' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+      end
+
+      context 'with an IPv4 address' do
+        let(:uri) { "http://127.0.0.1:#{TEST_WEBSERVER_PORT}/" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 1 endpoints' })) }
+      end
+
+      context 'with an IPv6 address' do
+        let(:uri) { "http://[::1]:#{TEST_WEBSERVER_PORT}/" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 1 endpoints' })) }
+      end
+    end
+
+    context 'when using encrypted https' do
+      before(:all) do
+        server_options = {
+          Port: TEST_WEBSERVER_PORT,
+          StartCallback: -> { @started = true },
+          AccessLog: [],
+          Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
+          SSLEnable: true,
+          SSLCertName: '/CN=example.com',
+        }
+        @server = WEBrick::HTTPServer.new(server_options)
+        @server.mount('/', Rack::Handler::WEBrick, TestWebserver)
+        @started = false
+        Thread.new { @server.start }
+        Timeout.timeout(1) { sleep(0.1) until @started }
+      end
+
+      after(:all) do
+        @server&.shutdown
+      end
+
+      context 'with an encrypted uri' do
+        let(:uri) { "https://example.com:#{TEST_WEBSERVER_PORT}/" }
+
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+      end
+    end
+
+    context 'with a wrong port' do
+      let(:uri) { 'http://example.com:23/' }
+
+      it { is_expected.to have_received(:report).with(hash_including({ service: 'get http://example.com:23/ consistency', state: 'critical', description: 'Could not get any response from example.com' })) }
+    end
+
+    context 'with a wrong domain' do
+      let(:uri) { 'https://invalid.example.com/' }
+
+      it { is_expected.to have_received(:report).with(hash_including({ service: 'get https://invalid.example.com/ consistency', state: 'critical', description: 'Could not get any response from invalid.example.com' })) }
+    end
+  end
+end


### PR DESCRIPTION
riemann-tools feature `riemann-portcheck` which can check if a port can be reached, but this is intended to check local services only and does not communicate over the connected socket, so can't detect some failure conditions like bad gateways.

Add a `riemann-http-check` that accept a list of URI of resources to check using HTTP(S) GET requests. For each URI, resolve the IP addresses that provide the service, and for each IP address generate 3 events: *connection latency*, *response latency* and *response code*. Then generate a last *consistency* event.

1. *connection latency* is a duration in seconds, the warning and critical threshold are respectively 100ms and 250ms, they can be tuned with the `--connection-latency-warning` and `--connection-latency-critical flags`;
 2. *response latency* is a duration in seconds, the warning and critical threshold are respectively 500ms and 1000ms, they can be tuned with the `--response-latency-warning` and `--response-latency-critical flags`;
 3. *response code* is the numeric response code and is looked for in a list of acceptable results, by default 200 OK, 301 Moved Permanently and 401 Unauthorized (other codes are considered to be non-working remote services);
 4. *consistency* reports an 'ok' state if all responses have the same response code and body.

When using HTTPS URI, the validity of certificates is *not* checked and any TLS error is silently ignored.  The idea is to only check for resource availability with this tool and have another tool to check for TLS connections in a generic — protocol agnostic — way.

### Sample output

```
riemann-http-check --uri http://riemann.io
```

> _localhost_ get http://riemann.io 185.199.108.153:80 connection latency **ok** 0.056760159
> _localhost_ get http://riemann.io 185.199.109.153:80 connection latency **ok** 0.057019915
> _localhost_ get http://riemann.io 185.199.110.153:80 connection latency **ok** 0.057262383
> _localhost_ get http://riemann.io 185.199.111.153:80 connection latency **ok** 0.058927338
> _localhost_ get http://riemann.io 185.199.108.153:80 response latency **ok** 0.121884269
> _localhost_ get http://riemann.io 185.199.109.153:80 response latency **ok** 0.122348656
> _localhost_ get http://riemann.io 185.199.110.153:80 response latency **ok** 0.119750327
> _localhost_ get http://riemann.io 185.199.111.153:80 response latency **ok** 0.120098131
> _localhost_ get http://riemann.io 185.199.108.153:80 response code **ok** 200
> _localhost_ get http://riemann.io 185.199.109.153:80 response code **ok** 200
> _localhost_ get http://riemann.io 185.199.110.153:80 response code **ok** 200
> _localhost_ get http://riemann.io 185.199.111.153:80 response code **ok** 200
> _localhost_ get http://riemann.io consistency **ok**
