### PR TITLE
Report mdstat health by device

### DIFF
--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -16,13 +16,13 @@ module Riemann
         status = File.read('/proc/mdstat')
         res = mdstat_parser.parse(status)
 
-        state = res.values.all? { |value| value =~ /\AU+\z/ } ? 'ok' : 'critical'
-
-        report(
-          service: 'mdstat',
-          description: status,
-          state: state,
-        )
+        res.each do |device, member_status|
+          report(
+            service: "mdstat #{device}",
+            description: member_status,
+            state: member_status =~ /\AU+\z/ ? 'ok' : 'critical',
+          )
+        end
       rescue Racc::ParseError => e
         report(
           service: 'mdstat',

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports ok state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md0', description: 'UU', state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md1', description: 'UU', state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md2', description: 'UU', state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md3', description: 'UUUUUUUUUU', state: 'ok')
       end
     end
 
@@ -24,7 +27,7 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'mdstat md127', description: 'UUUUU_', state: 'critical')
       end
     end
 


### PR DESCRIPTION
Instead of a single `mdstat` event reporting the global health status of
all md devices, generate one event per device.
