### PR TITLE
Allow mdstat device filtering

### DIFF
--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -8,6 +8,9 @@ module Riemann
     class Md
       include Riemann::Tools
 
+      opt :devices, 'Devices to monitor', type: :strings, default: []
+      opt :ignore_devices, 'Devices to ignore', type: :strings, default: []
+
       def mdstat_parser
         @mdstat_parser ||= MdstatParser.new
       end
@@ -17,6 +20,8 @@ module Riemann
         res = mdstat_parser.parse(status)
 
         res.each do |device, member_status|
+          next unless report_device?(device)
+
           report(
             service: "mdstat #{device}",
             description: member_status,
@@ -35,6 +40,14 @@ module Riemann
           description: e.message,
           state: 'critical',
         )
+      end
+
+      def report_device?(device)
+        if !opts[:devices].empty?
+          opts[:devices].include?(device)
+        else
+          !opts[:ignore_devices].include?(device)
+        end
       end
     end
   end

--- a/lib/riemann/tools/md.rb
+++ b/lib/riemann/tools/md.rb
@@ -16,13 +16,13 @@ module Riemann
         status = File.read('/proc/mdstat')
         res = mdstat_parser.parse(status)
 
-        state = res.values.all? { |value| value =~ /\AU+\z/ } ? 'ok' : 'critical'
-
-        report(
-          service: 'mdstat',
-          description: status,
-          state: state,
-        )
+        res.each do |device, member_status|
+          report(
+            service: "mdstat #{device}",
+            description: member_status,
+            state: member_status =~ /\AU+\z/ ? 'ok' : 'critical',
+          )
+        end
       rescue Racc::ParseError => e
         report(
           service: 'mdstat',

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -17,6 +17,36 @@ RSpec.describe Riemann::Tools::Md do
         expect(subject).to have_received(:report).with(service: 'mdstat md2', description: 'UU', state: 'ok')
         expect(subject).to have_received(:report).with(service: 'mdstat md3', description: 'UUUUUUUUUU', state: 'ok')
       end
+
+      context 'when filtering devices' do
+        before do
+          subject.opts[:devices] = %w[md1 md2]
+        end
+
+        it 'reports filtered devices state' do
+          allow(subject).to receive(:report)
+          subject.tick
+          expect(subject).not_to have_received(:report).with(service: 'mdstat md0', description: 'UU', state: 'ok')
+          expect(subject).to have_received(:report).with(service: 'mdstat md1', description: 'UU', state: 'ok')
+          expect(subject).to have_received(:report).with(service: 'mdstat md2', description: 'UU', state: 'ok')
+          expect(subject).not_to have_received(:report).with(service: 'mdstat md3', description: 'UUUUUUUUUU', state: 'ok')
+        end
+      end
+
+      context 'when ignoring devices' do
+        before do
+          subject.opts[:ignore_devices] = %w[md0 md1 md2]
+        end
+
+        it 'reports non ignored devices state' do
+          allow(subject).to receive(:report)
+          subject.tick
+          expect(subject).not_to have_received(:report).with(service: 'mdstat md0', description: 'UU', state: 'ok')
+          expect(subject).not_to have_received(:report).with(service: 'mdstat md1', description: 'UU', state: 'ok')
+          expect(subject).not_to have_received(:report).with(service: 'mdstat md2', description: 'UU', state: 'ok')
+          expect(subject).to have_received(:report).with(service: 'mdstat md3', description: 'UUUUUUUUUU', state: 'ok')
+        end
+      end
     end
 
     context 'when md devices are unhealthy' do

--- a/spec/riemann/tools/md_spec.rb
+++ b/spec/riemann/tools/md_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports ok state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md0', description: 'UU', state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md1', description: 'UU', state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md2', description: 'UU', state: 'ok')
+        expect(subject).to have_received(:report).with(service: 'mdstat md3', description: 'UUUUUUUUUU', state: 'ok')
       end
     end
 
@@ -24,7 +27,7 @@ RSpec.describe Riemann::Tools::Md do
       it 'reports critical state' do
         allow(subject).to receive(:report)
         subject.tick
-        expect(subject).to have_received(:report).with(service: 'mdstat', description: //, state: 'critical')
+        expect(subject).to have_received(:report).with(service: 'mdstat md127', description: 'UUUUU_', state: 'critical')
       end
     end
 


### PR DESCRIPTION
Now that we report each device independently, we can add filtering
capabilities to help monitoring Enterprise(R)(TM) Products with dubious
RAID configuration (I am looking at you Synology).

This PR also include:
  - #251
