### PR TITLE
Speed-up `riemann-http-check` with resolver and worker threads

### DIFF
--- a/lib/riemann/tools/diskstats.rb
+++ b/lib/riemann/tools/diskstats.rb
@@ -17,7 +17,7 @@ module Riemann
       def state
         f = File.read('/proc/diskstats')
         state = f.split("\n").reject { |d| d =~ /(ram|loop)/ }.each_with_object({}) do |line, s|
-          next unless line =~ /^(?:\s+\d+){2}\s+([\w\d\-]+) (.*)$/
+          next unless line =~ /^(?:\s+\d+){2}\s+([\w\d-]+) (.*)$/
 
           dev = Regexp.last_match(1)
 

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -8,8 +8,6 @@ require 'webrick/https'
 
 require 'riemann/tools/http_check'
 
-TEST_WEBSERVER_PORT = 65_391
-
 class TestWebserver < Sinatra::Base
   def authorized?
     @auth ||= Rack::Auth::Basic::Request.new(request.env)
@@ -84,7 +82,7 @@ RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= 
     context 'when using unencrypted http' do
       before(:all) do
         server_options = {
-          Port: TEST_WEBSERVER_PORT,
+          Port: 0,
           StartCallback: -> { @started = true },
           AccessLog: [],
           Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
@@ -100,106 +98,108 @@ RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= 
         @server&.shutdown
       end
 
+      let(:test_webserver_port) { @server.config[:Port] }
+
       let(:reported_uri) { uri }
 
       context 'with a fast uri' do
-        let(:uri) { URI("http://example.com:#{TEST_WEBSERVER_PORT}/") }
+        let(:uri) { URI("http://example.com:#{test_webserver_port}/") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ [::1]:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ [::1]:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ [::1]:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/ consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
       end
 
       context 'with a slow uri' do
-        let(:uri) { URI("http://example.com:#{TEST_WEBSERVER_PORT}/slow") }
+        let(:uri) { URI("http://example.com:#{test_webserver_port}/slow") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slow [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'warning' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slow 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'warning' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slow consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/slow [::1]:#{test_webserver_port} response latency", state: 'warning' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/slow 127.0.0.1:#{test_webserver_port} response latency", state: 'warning' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/slow consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
       end
 
       context 'with a very slow uri' do
-        let(:uri) { URI("http://example.com:#{TEST_WEBSERVER_PORT}/sloww") }
+        let(:uri) { URI("http://example.com:#{test_webserver_port}/sloww") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/sloww [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'critical' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/sloww 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'critical' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/sloww consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/sloww [::1]:#{test_webserver_port} response latency", state: 'critical' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/sloww 127.0.0.1:#{test_webserver_port} response latency", state: 'critical' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/sloww consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
       end
 
       context 'with a too slow uri' do
-        let(:uri) { URI("http://example.com:#{TEST_WEBSERVER_PORT}/slowww") }
+        let(:uri) { URI("http://example.com:#{test_webserver_port}/slowww") }
         let(:http_timeout) { 0.1 }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slowww [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'critical', description: 'timeout' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slowww 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'critical', description: 'timeout' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/slowww consistency", state: 'critical', description: 'Could not get any response from example.com' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/slowww [::1]:#{test_webserver_port} response latency", state: 'critical', description: 'timeout' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/slowww 127.0.0.1:#{test_webserver_port} response latency", state: 'critical', description: 'timeout' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/slowww consistency", state: 'critical', description: 'Could not get any response from example.com' })) }
       end
 
       context 'with inconsistent responses' do
-        let(:uri) { URI("http://example.com:#{TEST_WEBSERVER_PORT}/rand") }
+        let(:uri) { URI("http://example.com:#{test_webserver_port}/rand") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{TEST_WEBSERVER_PORT}/rand consistency", state: 'critical', description: '2 different response body on 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand [::1]:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand [::1]:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand [::1]:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand 127.0.0.1:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand 127.0.0.1:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand 127.0.0.1:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://example.com:#{test_webserver_port}/rand consistency", state: 'critical', description: '2 different response body on 2 endpoints' })) }
       end
 
       context 'with basic authentication and a good password' do
-        let(:uri) { URI("http://admin:secret@example.com:#{TEST_WEBSERVER_PORT}/protected") }
+        let(:uri) { URI("http://admin:secret@example.com:#{test_webserver_port}/protected") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected [::1]:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected [::1]:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected [::1]:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected 127.0.0.1:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected 127.0.0.1:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected 127.0.0.1:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
       end
 
       context 'with basic authentication and a wrong password' do
-        let(:uri) { URI("http://admin:wrong-password@example.com:#{TEST_WEBSERVER_PORT}/protected") }
+        let(:uri) { URI("http://admin:wrong-password@example.com:#{test_webserver_port}/protected") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 401, state: 'ok', description: '401 Unauthorized' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 401, state: 'ok', description: '401 Unauthorized' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{TEST_WEBSERVER_PORT}/protected consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected [::1]:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected [::1]:#{test_webserver_port} response code", metric: 401, state: 'ok', description: '401 Unauthorized' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected [::1]:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected 127.0.0.1:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected 127.0.0.1:#{test_webserver_port} response code", metric: 401, state: 'ok', description: '401 Unauthorized' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected 127.0.0.1:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://admin:**redacted**@example.com:#{test_webserver_port}/protected consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
       end
 
       context 'with an IPv4 address' do
-        let(:uri) { URI("http://127.0.0.1:#{TEST_WEBSERVER_PORT}/") }
+        let(:uri) { URI("http://127.0.0.1:#{test_webserver_port}/") }
         let(:addresses) { ['127.0.0.1'] }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 1 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://127.0.0.1:#{test_webserver_port}/ consistency", state: 'ok', description: 'consistent response on all 1 endpoints' })) }
       end
 
       context 'with an IPv6 address' do
-        let(:uri) { URI("http://[::1]:#{TEST_WEBSERVER_PORT}/") }
+        let(:uri) { URI("http://[::1]:#{test_webserver_port}/") }
         let(:addresses) { ['::1'] }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 1 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{test_webserver_port}/ [::1]:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{test_webserver_port}/ [::1]:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{test_webserver_port}/ [::1]:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get http://[::1]:#{test_webserver_port}/ consistency", state: 'ok', description: 'consistent response on all 1 endpoints' })) }
       end
     end
 
     context 'when using encrypted https' do
       before(:all) do
         server_options = {
-          Port: TEST_WEBSERVER_PORT,
+          Port: 0,
           StartCallback: -> { @started = true },
           AccessLog: [],
           Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
@@ -213,20 +213,22 @@ RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= 
         Timeout.timeout(1) { sleep(0.1) until @started }
       end
 
+      let(:test_webserver_port) { @server.config[:Port] }
+
       after(:all) do
         @server&.shutdown
       end
 
       context 'with an encrypted uri' do
-        let(:uri) { URI("https://example.com:#{TEST_WEBSERVER_PORT}/") }
+        let(:uri) { URI("https://example.com:#{test_webserver_port}/") }
 
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ [::1]:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} connection latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response code", metric: 200, state: 'ok', description: '200 OK' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ 127.0.0.1:#{TEST_WEBSERVER_PORT} response latency", state: 'ok' })) }
-        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{TEST_WEBSERVER_PORT}/ consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ [::1]:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ [::1]:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ [::1]:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} connection latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} response code", metric: 200, state: 'ok', description: '200 OK' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ 127.0.0.1:#{test_webserver_port} response latency", state: 'ok' })) }
+        it { is_expected.to have_received(:report).with(hash_including({ service: "get https://example.com:#{test_webserver_port}/ consistency", state: 'ok', description: 'consistent response on all 2 endpoints' })) }
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ARGV.replace([])
+
 RSpec.configure do |config|
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:


### PR DESCRIPTION
IP addresses resolution and HTTP resources fetching are I/O bound. When testing a large amount of HTTP endpoints, this can be an issue.  Some measurement we did for a use case show that checking 112 URI (most of them being serviced by 2 IP addresses) took 95 seconds.

Implement an address resolution queue and a working queue in order to parallelize tasks in multiple threads.  With a default of 5 resolvers and 20 workers, our test case now completes in about 4 seconds, which is more than 23 times faster.  These values can be tuned using the --resolvers and --workers new parameters.

While here, add metrics to track the resolvers and workers utilization and saturation.
