### PR TITLE
Allow opting out of `riemann-http-check` latency state

### DIFF
--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -205,7 +205,7 @@ module Riemann
         else
           report(
             {
-              state: 'critical',
+              state: latency_state(latency, nil),
               description: 'timeout',
             }.merge(endpoint_report(http, uri, "#{latency} latency")),
           )
@@ -213,9 +213,14 @@ module Riemann
       end
 
       def latency_state(name, latency)
-        if latency > opts["#{name}_latency_critical".to_sym]
+        critical_threshold = opts["#{name}_latency_critical".to_sym]
+        warning_threshold = opts["#{name}_latency_warning".to_sym]
+
+        return if critical_threshold.zero? || warning_threshold.zero?
+
+        if latency.nil? || latency > critical_threshold
           'critical'
-        elsif latency > opts["#{name}_latency_warning".to_sym]
+        elsif latency > warning_threshold
           'warning'
         else
           'ok'


### PR DESCRIPTION
By setting the warning and critical thresholds of the latency checks to
0, allow the metrics to be generated but do not attach a state to them.

This allows monitoring sites where connectivity is unreliable and we do
not really care about alerting when routing change and we suddently need
10 more seconds to reach the other side of the world.
