### PR TITLE
Fix `riemann-http-check` with unresolvable domains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+          - 3.2
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -42,7 +42,11 @@ module Riemann
               addresses = Resolv::DNS.new.getaddresses(host)
               if addresses.empty?
                 host = host[1...-1] if host[0] == '[' && host[-1] == ']'
-                addresses << IPAddr.new(host)
+                begin
+                  addresses << IPAddr.new(host)
+                rescue IPAddr::InvalidAddressError
+                  # Ignore
+                end
               end
 
               @work_queue.push([uri, addresses])


### PR DESCRIPTION
When the host part of an URI cannot be resolved, the `riemann-http-check` assume it is an IP address and attempt to parse it. But when this host is not an IP address, a `IPAddr::InvalidAddressError` exception is raised and is not catch, no metric is emitted, and the thread that raised the exception terminate.  On next attempt, another thread is killed, and soon no more resolver thread is available for the system to function properly.

Catch the `IPAddr::InvalidAddressError` exception and ignore it.  When the name is not resolvable, this produce a consistency metric with the critical state because no response can be collected for the URI.
