### PR TITLE
Override default HTTP User-Agent and make it tuneable

### DIFF
--- a/lib/riemann/tools/apache_status.rb
+++ b/lib/riemann/tools/apache_status.rb
@@ -16,7 +16,7 @@ module Riemann
       opt :uri, 'Apache Server Status URI', default: 'http://localhost/server-status'
 
       def initialize
-        @uri = "#{URI.parse(opts[:uri])}?auto"
+        @uri = URI.parse("#{opts[:uri]}?auto")
         # Sample Response with ExtendedStatus On
         # Total Accesses: 20643
         # Total kBytes: 36831

--- a/lib/riemann/tools/apache_status.rb
+++ b/lib/riemann/tools/apache_status.rb
@@ -14,6 +14,7 @@ module Riemann
       require 'uri'
 
       opt :uri, 'Apache Server Status URI', default: 'http://localhost/server-status'
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
         @uri = URI.parse("#{opts[:uri]}?auto")
@@ -68,7 +69,7 @@ module Riemann
       def connection
         response = nil
         begin
-          response = ::Net::HTTP.get(@uri)
+          response = ::Net::HTTP.new(@uri.host, @uri.port).get(@uri, { 'user-agent' => opts[:user_agent] }).body
         rescue StandardError => e
           report(
             service: 'httpd health',

--- a/lib/riemann/tools/cloudant.rb
+++ b/lib/riemann/tools/cloudant.rb
@@ -12,6 +12,7 @@ module Riemann
 
       opt :cloudant_username, 'Cloudant username', type: :string, required: true
       opt :cloudant_password, 'Cloudant pasword', type: :string, required: true
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def tick
         json.each do |node|
@@ -46,7 +47,7 @@ module Riemann
         http = ::Net::HTTP.new('cloudant.com', 443)
         http.use_ssl = true
         http.start do |h|
-          get = ::Net::HTTP::Get.new('/api/load_balancer')
+          get = ::Net::HTTP::Get.new('/api/load_balancer', { 'user-agent' => opts[:user_agent] })
           get.basic_auth opts[:cloudant_username], opts[:cloudant_password]
           h.request get
         end

--- a/lib/riemann/tools/consul_health.rb
+++ b/lib/riemann/tools/consul_health.rb
@@ -16,6 +16,7 @@ module Riemann
       opt :consul_port, 'Consul API Host (default to 8500)', default: '8500'
       opt :prefix, 'prefix to use for all service names when reporting', default: 'consul '
       opt :minimum_services_per_node, 'minimum services per node (default: 0)', default: 0
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
         @hostname = opts[:consul_host]
@@ -43,7 +44,7 @@ module Riemann
       end
 
       def get(url)
-        ::Net::HTTP.get_response(url).body
+        ::Net::HTTP.new(url.host, url.port).get(url, { 'user-agent' => opts[:user_agent] }).body
       end
 
       def tick

--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -12,6 +12,7 @@ module Riemann
 
       opt :stats_url, 'Full url to haproxy stats (eg: https://user:password@host.com:9999/stats)', required: true,
                                                                                                    type: :string
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
         @uri = URI("#{opts[:stats_url]};csv")
@@ -45,7 +46,7 @@ module Riemann
         http = ::Net::HTTP.new(@uri.host, @uri.port)
         http.use_ssl = true if @uri.scheme == 'https'
         res = http.start do |h|
-          get = ::Net::HTTP::Get.new(@uri.request_uri)
+          get = ::Net::HTTP::Get.new(@uri.request_uri, { 'user-agent' => opts[:user_agent] })
           unless @uri.userinfo.nil?
             userinfo = @uri.userinfo.split(':')
             get.basic_auth userinfo[0], userinfo[1]

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -28,6 +28,7 @@ module Riemann
       opt :checks, 'A list of checks to run.', short: :none, type: :strings, default: %w[consistency connection-latency response-code response-latency]
       opt :resolvers, 'Run this number of resolver threads', short: :none, type: :integer, default: 5
       opt :workers, 'Run this number of worker threads', short: :none, type: :integer, default: 20
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
         @resolve_queue = Queue.new
@@ -98,7 +99,7 @@ module Riemann
       end
 
       def test_uri_addresses(uri, addresses)
-        request = ::Net::HTTP::Get.new(uri)
+        request = ::Net::HTTP::Get.new(uri, { 'user-agent' => opts[:user_agent] })
         request.basic_auth(uri.user, uri.password)
 
         responses = []

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -58,9 +58,6 @@ module Riemann
           Thread.new do
             loop do
               uri, addresses = @work_queue.pop
-              request = ::Net::HTTP::Get.new(uri)
-              request.basic_auth(uri.user, uri.password)
-
               test_uri_addresses(uri, addresses)
             end
           end

--- a/lib/riemann/tools/nginx_status.rb
+++ b/lib/riemann/tools/nginx_status.rb
@@ -22,6 +22,7 @@ module Riemann
       opt :writing_critical, 'Writing connections critical threshold', default: 0
       opt :waiting_warning, 'Waiting connections warning threshold', default: 0
       opt :waiting_critical, 'Waiting connections critical threshold', default: 0
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
         @uri = URI.parse(opts[:uri])
@@ -53,7 +54,7 @@ module Riemann
       def tick
         response = nil
         begin
-          response = ::Net::HTTP.get(@uri)
+          response = ::Net::HTTP.new(@uri.host, @uri.port).get(@uri, { 'user-agent' => opts[:user_agent] }).body
         rescue StandardError => e
           report(
             service: 'nginx health',

--- a/tools/riemann-riak/lib/riemann/tools/riak.rb
+++ b/tools/riemann-riak/lib/riemann/tools/riak.rb
@@ -26,6 +26,8 @@ module Riemann
       opt :get_99_warning, 'FSM 99% get time warning threshold (ms)', default: 10_000
       opt :put_99_warning, 'FSM 99% put time warning threshold (ms)', default: 10_000
 
+      opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
+
       def initialize
         detect_features
 
@@ -38,7 +40,7 @@ module Riemann
           http.use_ssl = uri.scheme == 'https'
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
           http.start do |h|
-            h.get opts[:stats_path]
+            h.get(opts[:stats_path], { 'user-agent' => opts[:user_agent] })
           end
         rescue StandardError => _e
           @httpstatus = false
@@ -168,7 +170,7 @@ module Riemann
           http.use_ssl = uri.scheme == 'https'
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
           res = http.start do |h|
-            h.get opts[:stats_path]
+            h.get(opts[:stats_path], { 'user-agent' => opts[:user_agent] })
           end
         rescue StandardError => e
           report(


### PR DESCRIPTION
The default User-Agent for Net::HTTP is "Ruby".

![image](https://user-images.githubusercontent.com/148721/210443965-cbca71d9-d9ad-4455-8e19-7e5ba5f8905c.png)

In order to make it easier to distinguish traffic from various sources, change this default User-Agent string with a custom one based on the riemann tool name and version, and also include the project URL in the same way bots report their URL.

