### PR TITLE
Fix uninitialized constant Riemann::Tools::VERSION (NameError)

### DIFF
--- a/lib/riemann/tools/apache_status.rb
+++ b/lib/riemann/tools/apache_status.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Collects Apache metrics and submits them to Riemann
 # More information can be found at http://httpd.apache.org/docs/2.4/mod/mod_status.html

--- a/lib/riemann/tools/cloudant.rb
+++ b/lib/riemann/tools/cloudant.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Gathers load balancer statistics from Cloudant.com (shared cluster) and submits them to Riemann.
 module Riemann

--- a/lib/riemann/tools/consul_health.rb
+++ b/lib/riemann/tools/consul_health.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'riemann/tools'
+require 'riemann/tools/version'
 require 'socket'
 require 'net/http'
 require 'uri'

--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Gathers haproxy CSV statistics and submits them to Riemann.
 module Riemann

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -5,6 +5,7 @@ require 'resolv'
 require 'socket'
 
 require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Test for HTTP requests
 module Riemann

--- a/lib/riemann/tools/nginx_status.rb
+++ b/lib/riemann/tools/nginx_status.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Gathers nginx status stub statistics and submits them to Riemann.
 # See http://wiki.nginx.org/HttpStubStatusModule for configuring Nginx appropriately

--- a/tools/riemann-riak/lib/riemann/tools/riak.rb
+++ b/tools/riemann-riak/lib/riemann/tools/riak.rb
@@ -2,6 +2,7 @@
 
 require 'English'
 require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Forwards information on a Riak node to Riemann.
 module Riemann


### PR DESCRIPTION
When running the tools via bundler, `riemann/tools/version` is loaded and `Riemann::Tools::VERSION` is defined.  But when running as a gem, it is not loaded leading to an error at startup.

Explicitly require the version in the files that use it.