### PR TITLE
Send events in bulk when they are stacking

### DIFF
--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'optimist', '~> 3.0', '>= 3.0.0'
-  spec.add_runtime_dependency 'riemann-client', '~> 1.0'
+  spec.add_runtime_dependency 'riemann-client', '~> 1.1'
 
   spec.add_development_dependency 'github_changelog_generator'
   spec.add_development_dependency 'racc'


### PR DESCRIPTION
Sending an event to riemann can take some time. If during this time multiple events are generated, they will stack and be send one by one instead of being transmitted in bulk.

We added a new API function to riemann-client to send events in bulk:

* https://github.com/riemann/riemann-ruby-client/pull/44

Add a send queue and a worker thread that will send events in bulk if more than one is ready to be sent.

This is being tested ATM, the PR will be updated when we have collected enough data