### PR TITLE
Make sure all events are send before terminating

### DIFF
--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -73,7 +73,7 @@ module Riemann
     end
 
     def riemann
-      @riemann ||= RiemannClientWrapper.instance.configure(options)
+      @riemann ||= RiemannClientWrapper.new(options)
     end
     alias r riemann
 

--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -47,11 +47,17 @@ module Riemann
         end
         @worker.abort_on_exception = true
 
+        at_exit { drain }
+
         self
       end
 
       def <<(event)
         @queue << event
+      end
+
+      def drain
+        sleep(1) until @queue.empty?
       end
     end
   end

--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -7,33 +7,14 @@ require 'riemann/client'
 module Riemann
   module Tools
     class RiemannClientWrapper
-      include Singleton
+      attr_reader :options
 
-      def initialize
-        @client = nil
+      def initialize(options)
+        @options = options
+
         @queue = Queue.new
         @max_bulk_size = 1000
-      end
-
-      def configure(options)
-        return self unless @client.nil?
-
-        r = Riemann::Client.new(
-          host: options[:host],
-          port: options[:port],
-          timeout: options[:timeout],
-          ssl: options[:tls],
-          key_file: options[:tls_key],
-          cert_file: options[:tls_cert],
-          ca_file: options[:tls_ca_cert],
-          ssl_verify: options[:tls_verify],
-        )
-
-        @client = if options[:tcp] || options[:tls]
-                    r.tcp
-                  else
-                    r
-                  end
+        @draining = false
 
         @worker = Thread.new do
           loop do
@@ -42,21 +23,43 @@ module Riemann
             events << @queue.pop
             events << @queue.pop while !@queue.empty? && events.size < @max_bulk_size
 
-            @client.bulk_send(events)
+            client.bulk_send(events)
           end
         end
         @worker.abort_on_exception = true
 
         at_exit { drain }
+      end
 
-        self
+      def client
+        @client ||= begin
+          r = Riemann::Client.new(
+            host: options[:host],
+            port: options[:port],
+            timeout: options[:timeout],
+            ssl: options[:tls],
+            key_file: options[:tls_key],
+            cert_file: options[:tls_cert],
+            ca_file: options[:tls_ca_cert],
+            ssl_verify: options[:tls_verify],
+          )
+
+          if options[:tcp] || options[:tls]
+            r.tcp
+          else
+            r
+          end
+        end
       end
 
       def <<(event)
+        raise('Cannot queue events when draining') if @draining
+
         @queue << event
       end
 
       def drain
+        @draining = true
         sleep(1) until @queue.empty?
       end
     end

--- a/spec/riemann/tools/riemann_client_wrapper_spec.rb
+++ b/spec/riemann/tools/riemann_client_wrapper_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/riemann_client_wrapper'
+
+RSpec.describe Riemann::Tools::RiemannClientWrapper do
+  subject do
+    instance = described_class.new({})
+    client_mock = double
+    allow(client_mock).to receive(:bulk_send)
+    allow(instance).to receive(:client).and_return(client_mock)
+    instance
+  end
+
+  describe '#drain' do
+    it 'accepts events before draining' do
+      expect { subject << {} }.not_to raise_error
+    end
+
+    it 'does not accept events when draining' do
+      subject.drain
+      expect { subject << {} }.to raise_error(RuntimeError, 'Cannot queue events when draining')
+    end
+  end
+end


### PR DESCRIPTION
Now that we do not send events from the main thread, we must take care
to wait for events to be send when the main thread is about to exit.

When a short-lived riemann tool queue events for delivery and exit, this
will allow these events to be delivered.
