### PR TITLE
Improve event sending thread lifecycle management

### DIFF
--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -60,7 +60,7 @@ module Riemann
 
       def drain
         @draining = true
-        sleep(1) until @queue.empty?
+        sleep(1) until @queue.empty? || @worker.stop?
       end
     end
   end

--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -25,6 +25,11 @@ module Riemann
             events << @queue.pop while !@queue.empty? && events.size < @max_bulk_size
 
             client.bulk_send(events)
+          rescue Riemann::Client::Error => e
+            warn "Dropping #{events.size} event#{'s' if events.size > 1} due to #{e}"
+          rescue StandardError => e
+            warn "#{e.class} #{e}\n#{e.backtrace.join "\n"}"
+            Thread.main.terminate
           end
         end
 

--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -17,6 +17,7 @@ module Riemann
         @draining = false
 
         @worker = Thread.new do
+          Thread.current.abort_on_exception = true
           loop do
             events = []
 
@@ -26,7 +27,6 @@ module Riemann
             client.bulk_send(events)
           end
         end
-        @worker.abort_on_exception = true
 
         at_exit { drain }
       end


### PR DESCRIPTION
This PR add a bunch of enhancements to the event sender thread to make the system more resilient to transcient communication errors.

When riemann was unreachable, `riemann-wrapper` was terminating, and the other tools stopped trying to send events (even if riemann was reachable again).  This is now fixed by logging the failure and droping the events.  Other (unknown) errors in the event sending thread now cause a termination of the program in all cases, with some diagnostic messages.
