### PR TITLE
Gracefully handle all communication errors

### DIFF
--- a/lib/riemann/tools/riemann_client_wrapper.rb
+++ b/lib/riemann/tools/riemann_client_wrapper.rb
@@ -25,11 +25,8 @@ module Riemann
             events << @queue.pop while !@queue.empty? && events.size < @max_bulk_size
 
             client.bulk_send(events)
-          rescue Riemann::Client::Error => e
-            warn "Dropping #{events.size} event#{'s' if events.size > 1} due to #{e}"
           rescue StandardError => e
-            warn "#{e.class} #{e}\n#{e.backtrace.join "\n"}"
-            Thread.main.terminate
+            warn "Dropping #{events.size} event#{'s' if events.size > 1} due to #{e}"
           end
         end
 


### PR DESCRIPTION
We detect Riemann communication errors and in such circumstances, drop events and continue processing operations in order to cope with transient communication failures.

Some network errors raise generic `SocketError` exceptions, `OpenSSL::SSL::SSLError` or `EOFError` exceptions.  Such errors should likewise also be ignored instead of causing the program termination.
