### PR TITLE
Fix `riemann-haproxy` NoMethodError

### DIFF
--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -57,8 +57,8 @@ module Riemann
             get.basic_auth userinfo[0], userinfo[1]
           end
           h.request get
-          res.body
         end
+        res.body
       end
     end
   end


### PR DESCRIPTION
Previous refactoring was intended to make the code testable to unbreak
it, but a copy/paste error in the non-tested code path was introduced
causing an exception at runtime:

```
NoMethodError undefined method `body' for nil:NilClass
```

Move the line at the right position where `res` is available.
