### PR TITLE
Allow using the latest version of rack (3.x)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,14 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in riemann-tools.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+  # XXX: Needed for Ruby 2.6 compatibility
+  #
+  # With Ruby 2.6 an older version of rakup is installed that cause other gems
+  # to be installed with a legacy version.
+  #
+  # Because rakup is only needed when using rack 3, we can just ignore this
+  # with Ruby 2.6.
+  gem 'rackup'
+end

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'openssl'
-require 'rack/handler/webrick'
+begin
+  require 'rackup/handler/webrick'
+rescue LoadError
+  # XXX: Needed for Ruby 2.6 compatibility
+  # Moved to the rackup gem in recent versions
+  require 'rack/handler/webrick'
+end
 require 'sinatra/base'
 require 'webrick'
 require 'webrick/https'


### PR DESCRIPTION
The project dependencies now allow rack 3 to be installed.  This backwards incompatible version extracted handlers in a new `rackup` gem.  While we could indicate we prefer to use rack 2 which is still receiving update, it is more future-proof to update our code to be compatible with the latest version of the dependency.

This is a development dependency only so will not affect users of the project.
