### PR TITLE
Terminate `Riemann::Tools::HttpCheck` threads between tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,14 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in riemann-tools.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+  # XXX: Needed for Ruby 2.6 compatibility
+  #
+  # With Ruby 2.6 an older version of rakup is installed that cause other gems
+  # to be installed with a legacy version.
+  #
+  # Because rakup is only needed when using rack 3, we can just ignore this
+  # with Ruby 2.6.
+  gem 'rackup'
+end

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -37,10 +37,15 @@ module Riemann
         @resolve_queue = Queue.new
         @work_queue = Queue.new
 
+        @resolvers = []
+        @workers = []
+
         opts[:resolvers].times do
-          Thread.new do
+          @resolvers << Thread.new do
             loop do
               uri = @resolve_queue.pop
+              Thread.exit unless uri
+
               host = uri.host
 
               addresses = Resolv::DNS.new.getaddresses(host)
@@ -59,15 +64,34 @@ module Riemann
         end
 
         opts[:workers].times do
-          Thread.new do
+          @workers << Thread.new do
             loop do
               uri, addresses = @work_queue.pop
+              Thread.exit unless uri
+
               test_uri_addresses(uri, addresses)
             end
           end
         end
 
         super
+      end
+
+      # Under normal operation, we have a single instance of this class for the
+      # lifetime of the process.  But when testing, we create a new instance
+      # for each test, each with its resolvers and worker threads.  The test
+      # process may end-up with a lot of running threads, hitting the OS limit
+      # of max threads by process and being unable to create more thread:
+      #
+      # ThreadError: can't create Thread: Resource temporarily unavailable
+      #
+      # To avoid this situation, we provide this method.
+      def shutdown
+        @resolve_queue.close
+        @resolvers.map(&:join)
+
+        @work_queue.close
+        @workers.map(&:join)
       end
 
       def tick

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= 
         @server&.shutdown
       end
 
+      after(:each) do
+        subject.shutdown
+      end
+
       let(:test_webserver_port) { @server.config[:Port] }
 
       let(:reported_uri) { uri }

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'openssl'
-require 'rack/handler/webrick'
+begin
+  require 'rackup/handler/webrick'
+rescue LoadError
+  # XXX: Needed for Ruby 2.6 compatibility
+  # Moved to the rackup gem in recent versions
+  require 'rack/handler/webrick'
+end
 require 'sinatra/base'
 require 'webrick'
 require 'webrick/https'


### PR DESCRIPTION
Under normal operation, we have a single instance of the `Riemann::Tools::HttpCheck` class for the lifetime of the monitoring process.

But when testing, we create a new instance for each test, each with its resolvers and worker thread pools.  The test process will have more and more threads, until it eventually hit the OS limit of the maximum number of threads for a process and cause an exception:

> ThreadError: can't create Thread: Resource temporarily unavailable

Make sure that the threads are terminated at the end of each test to avoid running out of resources if they are limited.

Also include:
* #283 