### PR TITLE
Add Ruby 3.3 to the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
@@ -32,6 +32,7 @@ jobs:
           - 3.0
           - 3.1
           - 3.2
+          - 3.3
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby


### PR DESCRIPTION
While here, update the version of Ruby used for "commonn" steps to use a
supported one.
