### PR TITLE
Fix `riemann-health` memory reporting when using ZFS on Linux

### DIFF
--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -128,10 +128,8 @@ module Riemann
       def test_uri_addresses(uri, addresses)
         request = get_request(uri)
 
-        responses = []
-
-        addresses.each do |address|
-          responses << test_uri_address(uri, address.to_s, request)
+        responses = addresses.map do |address|
+          test_uri_address(uri, address.to_s, request)
         end
 
         responses.compact!

--- a/tools/riemann-docker/lib/riemann/tools/docker.rb
+++ b/tools/riemann-docker/lib/riemann/tools/docker.rb
@@ -171,10 +171,8 @@ module Riemann
         disk if @disk_enabled
 
         # Get CPU, Memory and Load of each container
-        threads = []
-
-        containers.each do |ctr|
-          threads << Thread.new(ctr) do |container|
+        threads = containers.map do |ctr|
+          Thread.new(ctr) do |container|
             id = container.id
             name = get_container_name(container)
 


### PR DESCRIPTION
On Linux, memory used by the ZFS ARC is reported as used while in fact
it mostly consist of cached data that can be reclaimed by the operating
system if necessary.

If the system use ZFS, gather the ARC statistics to compute the size
of the ARC that can be evicted and do not count this as used memory.
This fix the obviously wrong reporting we can see on systems running
ZFS.

Containers running on nodes with ZFS can access the hosts ARC
statistics from the container, resulting in wrong memory reporting.  To
avoid this, we detect if we are running from a container and skip
reading the ARC statistics in that case.
