### PR TITLE
Fix `riemann-wrapper` with older Ruby

### DIFF
--- a/bin/riemann-wrapper
+++ b/bin/riemann-wrapper
@@ -116,7 +116,7 @@ if ARGV.size == 1
   end
 
   require 'yaml'
-  config = YAML.safe_load_file(ARGV[0])
+  config = YAML.safe_load(File.read(ARGV[0]))
 
   arguments = split_options(config['options'])
   config['tools'].each do |tool|


### PR DESCRIPTION
This reverts commit b4254bdb13658a9f65b1d1ee2efa1e7cbf1d834c.

The YAML.safe_load_file function was added in Psych 3.2.1, but only Ruby
3 and newer provide this version of the Psych library.  Since this gem
is supposed to work with older (EOL) Ruby versions, revert this for now.

At some point we will drop support for EOL Ruby, but it will be a
backwards incompatbile change and there is no hurry for that at the
moment, and some supported Linux distro still ship these legacy Ruby
versions.
