### PR TITLE
Fix mixing `#opts` and `#options`

### DIFF
--- a/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
@@ -21,7 +21,7 @@ module Riemann
         opt :time_end, 'End time in seconds of the metrics period ', type: Integer, default: 60
 
         def initialize
-          if options[:fog_credentials_file]
+          if opts[:fog_credentials_file]
             Fog.credentials_path = opts[:fog_credentials_file]
             Fog.credential = opts[:fog_credential].to_sym
             @cloudwatch = Fog::AWS::CloudWatch.new

--- a/tools/riemann-aws/lib/riemann/tools/aws/status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/status.rb
@@ -20,21 +20,21 @@ module Riemann
         opt :event_warning, 'Number of days before event. Defaults to nil (i.e. when the event appears)', default: nil
 
         def initialize
-          if options[:fog_credentials_file]
-            Fog.credentials_path = options[:fog_credentials_file]
-            Fog.credential = options[:fog_credential].to_sym
+          if opts[:fog_credentials_file]
+            Fog.credentials_path = opts[:fog_credentials_file]
+            Fog.credential = opts[:fog_credential].to_sym
             @compute = Fog::AWS::Compute.new
           else
-            @compute = if options[:access_key] && options[:secret_key]
+            @compute = if opts[:access_key] && opts[:secret_key]
                          Fog::AWS::Compute.new({
-                                                 access_key_key_id: options[:access_key],
-                                                 secret_key_access_key: options[:secret_key],
-                                                 region: options[:region],
+                                                 access_key_key_id: opts[:access_key],
+                                                 secret_key_access_key: opts[:secret_key],
+                                                 region: opts[:region],
                                                })
                        else
                          Fog::AWS::Compute.new({
                                                  use_iam_profile: true,
-                                                 region: options[:region],
+                                                 region: opts[:region],
                                                })
                        end
           end

--- a/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
+++ b/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
@@ -27,8 +27,8 @@ module Riemann
 
       def base_url
         protocol = 'http'
-        protocol = 'https' if options[:monitor_use_tls] && (options[:monitor_use_tls] == true)
-        "#{protocol}://#{options[:monitor_user]}:#{options[:monitor_pass]}@#{options[:monitor_host]}:#{options[:monitor_port]}/api"
+        protocol = 'https' if opts[:monitor_use_tls] && (opts[:monitor_use_tls] == true)
+        "#{protocol}://#{opts[:monitor_user]}:#{opts[:monitor_pass]}@#{opts[:monitor_host]}:#{opts[:monitor_port]}/api"
       end
 
       def overview_url
@@ -44,7 +44,7 @@ module Riemann
       end
 
       def event_host
-        options[:event_host] || :monitor_host
+        opts[:event_host] || :monitor_host
       end
 
       def safe_get(uri, event_host)
@@ -53,8 +53,8 @@ module Riemann
         begin
           connection = Faraday.new(uri)
           response = connection.get do |req|
-            req.options[:timeout] = options[:read_timeout]
-            req.options[:open_timeout] = options[:open_timeout]
+            req.opts[:timeout] = opts[:read_timeout]
+            req.opts[:open_timeout] = opts[:open_timeout]
           end
           report(
             host: event_host,
@@ -75,7 +75,7 @@ module Riemann
 
       def check_queues
         response = safe_get(queues_url, event_host)
-        max_size_check_filter = (Regexp.new(options[:ignore_max_size_queues]) if options[:ignore_max_size_queues])
+        max_size_check_filter = (Regexp.new(opts[:ignore_max_size_queues]) if opts[:ignore_max_size_queues])
 
         return if response.nil?
 
@@ -102,7 +102,7 @@ module Riemann
 
             errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && (queue['messages_ready']).positive? && (queue['consumers']).zero?
 
-            errs << "Queue has #{queue['messages_ready']} jobs" if (max_size_check_filter.nil? || queue['name'] !~ (max_size_check_filter)) && !queue['messages_ready'].nil? && (queue['messages_ready'] > options[:max_queue_size])
+            errs << "Queue has #{queue['messages_ready']} jobs" if (max_size_check_filter.nil? || queue['name'] !~ (max_size_check_filter)) && !queue['messages_ready'].nil? && (queue['messages_ready'] > opts[:max_queue_size])
 
             if errs.empty?
               report(


### PR DESCRIPTION
`#opts` is an alias for `#options` in the `Riemann::Tools` class.

While most of the tools use `#opts`, a few ones une `#options`, but the
files in this commit use both functions, which can cause confusion.

To avoid this, stick to `#opts`.  Files that consitently use `#options`
are kept as is.

No functional change.
