### PR TITLE
Fix `riemann-nginx` checks selection

### DIFF
--- a/lib/riemann/tools/nginx_status.rb
+++ b/lib/riemann/tools/nginx_status.rb
@@ -75,6 +75,8 @@ module Riemann
         values = @re.match(response).to_a[1, 7].map(&:to_i)
 
         @keys.zip(values).each do |key, value|
+          next unless opts[:checks].include?(key)
+
           report({
                    service: "nginx #{key}",
                    metric: value,


### PR DESCRIPTION
The `riemann-nginx` tool accept a `--checks` parameter since it was
introduced in #33, but this parameter was never used to filter events.

Make sure we only return events that match the provided checks.
