### PR TITLE
Detect and report stray arguments

### DIFF
--- a/lib/riemann/tools.rb
+++ b/lib/riemann/tools.rb
@@ -44,6 +44,14 @@ module Riemann
       end
     end
 
+    attr_reader :argv
+
+    def initialize(allow_arguments: false)
+      options
+      @argv = ARGV.dup
+      abort "Error: stray arguments: #{ARGV.map(&:inspect).join(', ')}" if ARGV.any? && !allow_arguments
+    end
+
     # Returns parsed options (cached) from command line.
     def options
       @options ||= self.class.options
@@ -58,10 +66,7 @@ module Riemann
     end
 
     def report(event)
-      if options[:tag]
-        # Work around a bug with beefcake which can't take frozen strings.
-        event[:tags] = [*event.fetch(:tags, [])] + options[:tag].map(&:dup)
-      end
+      event[:tags] = event.fetch(:tags, []) + options[:tag]
 
       event[:ttl] ||= options[:ttl] || (options[:interval] * 2)
 

--- a/lib/riemann/tools/apache_status.rb
+++ b/lib/riemann/tools/apache_status.rb
@@ -18,6 +18,8 @@ module Riemann
       opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
+        super
+
         @uri = URI.parse("#{opts[:uri]}?auto")
         # Sample Response with ExtendedStatus On
         # Total Accesses: 20643

--- a/lib/riemann/tools/bench.rb
+++ b/lib/riemann/tools/bench.rb
@@ -11,6 +11,8 @@ module Riemann
       attr_accessor :client, :hosts, :services, :states
 
       def initialize
+        super
+
         @hosts = [nil] + (0...10).map { |i| "host#{i}" }
         @hosts = %w[a b c d e f g h i j]
         @services = %w[test1 test2 test3 foo bar baz xyzzy attack cat treat]

--- a/lib/riemann/tools/consul_health.rb
+++ b/lib/riemann/tools/consul_health.rb
@@ -20,6 +20,8 @@ module Riemann
       opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
+        super
+
         @hostname = opts[:consul_host]
         @prefix = opts[:prefix]
         @minimum_services_per_node = opts[:minimum_services_per_node]

--- a/lib/riemann/tools/dir_files_count.rb
+++ b/lib/riemann/tools/dir_files_count.rb
@@ -15,6 +15,8 @@ module Riemann
       opt :alert_on_missing, 'Send a critical metric if the directory is missing?', default: true
 
       def initialize
+        super
+
         @dir = opts.fetch(:directory)
         @service_prefix = opts.fetch(:service_prefix)
         @warning = opts.fetch(:warning, nil)

--- a/lib/riemann/tools/dir_space.rb
+++ b/lib/riemann/tools/dir_space.rb
@@ -15,6 +15,8 @@ module Riemann
       opt :alert_on_missing, 'Send a critical metric if the directory is missing?', default: true
 
       def initialize
+        super
+
         @dir = opts.fetch(:directory)
         @service_prefix = opts.fetch(:service_prefix)
         @warning = opts.fetch(:warning, nil)

--- a/lib/riemann/tools/diskstats.rb
+++ b/lib/riemann/tools/diskstats.rb
@@ -11,6 +11,8 @@ module Riemann
       opt :ignore_devices, 'Devices to ignore', type: :strings, default: nil
 
       def initialize
+        super
+
         @old_state = nil
       end
 

--- a/lib/riemann/tools/fd.rb
+++ b/lib/riemann/tools/fd.rb
@@ -16,6 +16,8 @@ module Riemann
       opt :processes, 'list of processes to measure fd usage in addition to system total', type: :ints
 
       def initialize
+        super
+
         @limits = {
           fd: { critical: opts[:fd_sys_critical], warning: opts[:fd_sys_warning] },
           process: { critical: opts[:fd_proc_critical], warning: opts[:fd_proc_warning] },

--- a/lib/riemann/tools/freeswitch.rb
+++ b/lib/riemann/tools/freeswitch.rb
@@ -13,6 +13,8 @@ module Riemann
       opt :pid_file, 'FreeSWITCH daemon pidfile', type: String, default: '/var/run/freeswitch/freeswitch.pid'
 
       def initialize
+        super
+
         @limits = {
           calls: { critical: opts[:calls_critical], warning: opts[:calls_warning] },
         }

--- a/lib/riemann/tools/haproxy.rb
+++ b/lib/riemann/tools/haproxy.rb
@@ -16,6 +16,8 @@ module Riemann
       opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
+        super
+
         @uri = URI("#{opts[:stats_url]};csv")
       end
 

--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -35,6 +35,8 @@ module Riemann
       opt :checks, 'A list of checks to run.', type: :strings, default: %w[cpu load memory disk swap]
 
       def initialize
+        super
+
         @limits = {
           cpu: { critical: opts[:cpu_critical], warning: opts[:cpu_warning] },
           disk: { critical: opts[:disk_critical], warning: opts[:disk_warning], critical_leniency_kb: human_size_to_number(opts[:disk_critical_leniency]) / 1024, warning_leniency_kb: human_size_to_number(opts[:disk_warning_leniency]) / 1024 },

--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -34,6 +34,8 @@ module Riemann
       opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
+        super
+
         @resolve_queue = Queue.new
         @work_queue = Queue.new
 
@@ -73,8 +75,6 @@ module Riemann
             end
           end
         end
-
-        super
       end
 
       # Under normal operation, we have a single instance of this class for the

--- a/lib/riemann/tools/net.rb
+++ b/lib/riemann/tools/net.rb
@@ -12,6 +12,8 @@ module Riemann
       opt :ignore_interfaces, 'Interfaces to ignore', type: :strings, default: ['\Alo\d*\z']
 
       def initialize
+        super
+
         @old_state = nil
         @interfaces = if opts[:interfaces]
                         opts[:interfaces].reject(&:empty?).map(&:dup)

--- a/lib/riemann/tools/nginx_status.rb
+++ b/lib/riemann/tools/nginx_status.rb
@@ -26,6 +26,8 @@ module Riemann
       opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
+        super
+
         @uri = URI.parse(opts[:uri])
 
         # sample response:

--- a/lib/riemann/tools/ntp.rb
+++ b/lib/riemann/tools/ntp.rb
@@ -9,6 +9,8 @@ module Riemann
       include Riemann::Tools
 
       def initialize
+        super
+
         @hostname = `hostname`.chomp
         @ostype = `uname -s`.chomp.downcase
         abort 'WARNING: macOS not explicitly supported. Exiting.' if @ostype == 'darwin'

--- a/lib/riemann/tools/portcheck.rb
+++ b/lib/riemann/tools/portcheck.rb
@@ -14,6 +14,8 @@ module Riemann
       opt :ports, "List of ports to check, e.g. '-r 80 443'", type: :ints
 
       def initialize
+        super
+
         @hostname = opts.fetch(:hostname)
         @ports = opts.fetch(:ports)
       end

--- a/lib/riemann/tools/proc.rb
+++ b/lib/riemann/tools/proc.rb
@@ -13,6 +13,8 @@ module Riemann
       opt :proc_max_critical, 'running process count maximum', default: 65_536
 
       def initialize
+        super
+
         @limits = { critical: { min: opts[:proc_min_critical], max: opts[:proc_max_critical] } }
 
         abort 'FATAL: specify a process regular expression, see --help for usage' unless opts[:proc_regex]

--- a/lib/riemann/tools/varnish.rb
+++ b/lib/riemann/tools/varnish.rb
@@ -12,6 +12,8 @@ module Riemann
       opt :varnish_host, 'Varnish hostname', default: `hostname`.chomp
 
       def initialize
+        super
+
         cmd = 'varnishstat -V'
         Open3.popen3(cmd) do |_stdin, _stdout, stderr, _wait_thr|
           @ver = /varnishstat \(varnish-(\d+)/.match(stderr.read)[1].to_i

--- a/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/billing.rb
@@ -21,6 +21,8 @@ module Riemann
         opt :time_end, 'End time in seconds of the metrics period ', type: Integer, default: 60
 
         def initialize
+          super
+
           if opts[:fog_credentials_file]
             Fog.credentials_path = opts[:fog_credentials_file]
             Fog.credential = opts[:fog_credential].to_sym

--- a/tools/riemann-aws/lib/riemann/tools/aws/rds_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/rds_status.rb
@@ -17,6 +17,8 @@ module Riemann
         opt :region, 'AWS region', type: String, default: 'eu-west-1'
         opt :dbinstance_identifier, 'DBInstanceIdentifier', type: String
         def initialize
+          super
+
           abort 'FATAL: specify a DB instance name, see --help for usage' unless opts[:dbinstance_identifier]
           creds = if opts[:access_key] && opts[:secret_key]
                     {

--- a/tools/riemann-aws/lib/riemann/tools/aws/sqs_status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/sqs_status.rb
@@ -14,6 +14,8 @@ module Riemann
         opt :region, 'AWS region', type: String, default: 'us-east-1'
         opt :queue, 'SQS Queue name', type: String
         def initialize
+          super
+
           creds = if opts.key?('access_key') && opts.key?('secret_key')
                     {
                       aws_access_key_id: opts[:access_key],

--- a/tools/riemann-aws/lib/riemann/tools/aws/status.rb
+++ b/tools/riemann-aws/lib/riemann/tools/aws/status.rb
@@ -20,6 +20,8 @@ module Riemann
         opt :event_warning, 'Number of days before event. Defaults to nil (i.e. when the event appears)', default: nil
 
         def initialize
+          super
+
           if opts[:fog_credentials_file]
             Fog.credentials_path = opts[:fog_credentials_file]
             Fog.credential = opts[:fog_credential].to_sym

--- a/tools/riemann-chronos/lib/riemann/tools/chronos.rb
+++ b/tools/riemann-chronos/lib/riemann/tools/chronos.rb
@@ -21,6 +21,8 @@ module Riemann
       def initialize
         options[:interval] = 60
         options[:ttl] = 120
+
+        super
       end
 
       # Handles HTTP connections and GET requests safely

--- a/tools/riemann-docker/lib/riemann/tools/docker.rb
+++ b/tools/riemann-docker/lib/riemann/tools/docker.rb
@@ -31,6 +31,8 @@ module Riemann
       end
 
       def initialize
+        super
+
         Docker.url = opts[:docker_host] unless opts[:docker_host].nil?
 
         @hostname = opts[:host_hostname]

--- a/tools/riemann-marathon/lib/riemann/tools/marathon.rb
+++ b/tools/riemann-marathon/lib/riemann/tools/marathon.rb
@@ -21,6 +21,8 @@ module Riemann
       def initialize
         options[:interval] = 60
         options[:ttl] = 120
+
+        super
       end
 
       # Handles HTTP connections and GET requests safely

--- a/tools/riemann-munin/lib/riemann/tools/munin.rb
+++ b/tools/riemann-munin/lib/riemann/tools/munin.rb
@@ -10,6 +10,8 @@ module Riemann
       require 'munin-ruby'
 
       def initialize
+        super
+
         @munin = ::Munin::Node.new
       end
 

--- a/tools/riemann-riak/lib/riemann/tools/riak.rb
+++ b/tools/riemann-riak/lib/riemann/tools/riak.rb
@@ -30,6 +30,8 @@ module Riemann
       opt :user_agent, 'User-Agent header for HTTP requests', short: :none, default: "#{File.basename($PROGRAM_NAME)}/#{Riemann::Tools::VERSION} (+https://github.com/riemann/riemann-tools)"
 
       def initialize
+        super
+
         detect_features
 
         @httpstatus = true


### PR DESCRIPTION
When a tool is run with stray arguments, they are silently ignored. This typically happen when a parameter must be repeated for each value (e.g. the `--tag` parameter is passed multiple values with `--tag foo --tag bar` and passing `--tag foo bar` only provide a single tag and the `bar` value is an argument that is silently ignored).

In order to avoid this issue, raise an error by default if stray arguments are found.  It is possible to indicate that stray arguments are allowed by expilcitly saying so.  In this case, the arguments are accessible using the `#argv` method.
