### PR TITLE
Add support for a minimum TTL for events

### DIFF
--- a/spec/riemann/tools_spec.rb
+++ b/spec/riemann/tools_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'riemann/tools/health'
+
+class ExampleTool
+  include Riemann::Tools
+end
+
+RSpec.describe Riemann::Tools do
+  describe '#options' do
+    describe ':ttl' do
+      subject(:tool) { ExampleTool.new }
+
+      {
+        ''                           => 10,
+        '--ttl=60'                   => 60,
+        '--interval 10'              => 20,
+        '--minimum-ttl 300'          => 300,
+        '--minimum-ttl 300 --ttl=60' => 300,
+        '--minimum-ttl 30 --ttl 60'  => 60,
+      }.each do |argv, expected_ttl|
+        context "with ARGV=\"#{argv}\"" do
+          before do
+            ARGV.replace argv.split
+          end
+
+          it { expect(tool.options[:ttl]).to eq expected_ttl }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When running with riemann-wrappers, one may want to run different tools with distinct ttl, but the `--ttl` flag cannot be specified twice, so the following configuration where we want to run the `health` tool every 5 seconds (default value) but with a longer TTL than the default (twice the interval) will **not** work:

```yaml
---
options: --ttl 300
#        ^^^^^^^^^
tools:
- name: "health"
- name: "rdap"
  options: "--interval 21600 --ttl 86400 --domains example.com example.net"
#                            ^^^^^^^^^^^
```

A workaround is to add an explicit ttl for each tool, but it is not convenient.

Introduce a `--minimum-ttl` flag that can be used as a global option to circumvent this issue:

```yaml
---
options: --minimum-ttl 300
tools:
- name: "health"
- name: "rdap"
  options: "--interval 21600 --ttl 86400 --domains example.com example.net"
```