### PR TITLE
Improve riemann-bench

### DIFF
--- a/lib/riemann/tools/bench.rb
+++ b/lib/riemann/tools/bench.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-require 'rubygems'
-require 'riemann/client'
+require 'riemann/tools'
+require 'riemann/tools/version'
 
 # Connects to a server (first arg) and populates it with a constant stream of
 # events for testing.
 module Riemann
   module Tools
     class Bench
-      attr_accessor :client, :hosts, :services, :states
+      include Riemann::Tools
+      attr_accessor :hosts, :services, :states
 
       def initialize
         super
@@ -17,7 +18,6 @@ module Riemann
         @hosts = %w[a b c d e f g h i j]
         @services = %w[test1 test2 test3 foo bar baz xyzzy attack cat treat]
         @states = {}
-        @client = Riemann::Client.new(host: ARGV.first || 'localhost')
       end
 
       def evolve(state)
@@ -45,7 +45,7 @@ module Riemann
       def tick
         #    pp @states
         hosts.product(services).each do |id|
-          client << (states[id] = evolve(states[id]))
+          report(states[id] = evolve(states[id]))
         end
       end
 

--- a/lib/riemann/tools/tls_check.rb
+++ b/lib/riemann/tools/tls_check.rb
@@ -478,7 +478,7 @@ module Riemann
         capabilities = initial_handshake_packet[5] | (initial_handshake_packet[8] << 16)
 
         ssl_flag = 1 << 11
-        raise 'No TLS support' if (capabilities & ssl_flag).zero?
+        raise 'No TLS support' if capabilities.nobits?(ssl_flag)
 
         socket.write(['2000000185ae7f0000000001210000000000000000000000000000000000000000000000'].pack('H*'))
         tls_handshake(socket, uri.host)

--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'json', '>= 1.8'
-  spec.add_runtime_dependency 'optimist', '~> 3.0', '>= 3.0.0'
-  spec.add_runtime_dependency 'riemann-client', '~> 1.1'
+  spec.add_dependency 'json', '>= 1.8'
+  spec.add_dependency 'optimist', '~> 3.0', '>= 3.0.0'
+  spec.add_dependency 'riemann-client', '~> 1.1'
 end

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -17,6 +17,8 @@ require 'webrick/https'
 require 'riemann/tools/http_check'
 
 class TestWebserver < Sinatra::Base
+  set :host_authorization, { permitted_hosts: [] }
+
   def authorized?
     @auth ||= Rack::Auth::Basic::Request.new(request.env)
     @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == %w[admin secret]


### PR DESCRIPTION
Unlike other clients, riemann-bench only support a connection to riemann
using default parameters and has no way to tune it.

Use the same pattern as used in other tools so that we have a unified
command line interface accross tools.
