### PR TITLE
Ignore invalid data in `riemann-hwmon`

### DIFF
--- a/lib/riemann/tools/hwmon.rb
+++ b/lib/riemann/tools/hwmon.rb
@@ -104,6 +104,8 @@ module Riemann
       def tick
         devices.each do |device|
           report(device.report)
+        rescue Errno::ENODATA
+          # Some sensors are buggy and cannot report properly
         end
       end
     end

--- a/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
+++ b/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
@@ -100,7 +100,7 @@ module Riemann
             svc = "rabbitmq.queue.#{queue['vhost']}.#{queue['name']}"
             errs = []
 
-            errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && (queue['messages_ready']).positive? && (queue['consumers']).zero?
+            errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && queue['messages_ready'].positive? && queue['consumers'].zero?
 
             errs << "Queue has #{queue['messages_ready']} jobs" if (max_size_check_filter.nil? || queue['name'] !~ (max_size_check_filter)) && !queue['messages_ready'].nil? && (queue['messages_ready'] > opts[:max_queue_size])
 


### PR DESCRIPTION
After updating some nodes of our infra, we stated to see this error
filling the logs:
```
Errno::ENODATA No data available @ io_fread - /sys/class/hwmon/hwmon4/temp1_input
+12 lines of backtrace
```

Indeed, the sensor system seems somewhat broken:

```
root@xylophone ~ # cat /sys/class/hwmon/hwmon4/temp1_input
cat: /sys/class/hwmon/hwmon4/temp1_input: No data available
root@xylophone ~ # echo $?
1
```

Catch such exception and ignore it as there is nothing better we can do
for now.
