### PR TITLE
Ignore `efivarfs` disks in `riemann-health` checks

### DIFF
--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -21,7 +21,7 @@ module Riemann
       opt :disk_warning_leniency, 'Disk warning threshold (amount of free space)', short: :none, default: '500G'
       opt :disk_critical_leniency, 'Disk critical threshold (amount of free space)', short: :none, default: '250G'
       opt :disk_ignorefs, 'A list of filesystem types to ignore',
-          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs squashfs tmpfs]
+          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs efivarfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs squashfs tmpfs]
       opt :load_warning, 'Load warning threshold (load average / core)', default: 3.0
       opt :load_critical, 'Load critical threshold (load average / core)', default: 8.0
       opt :memory_warning, 'Memory warning threshold (fraction of RAM)', default: 0.85

--- a/lib/riemann/tools/hwmon.rb
+++ b/lib/riemann/tools/hwmon.rb
@@ -104,6 +104,8 @@ module Riemann
       def tick
         devices.each do |device|
           report(device.report)
+        rescue Errno::ENODATA
+          # Some sensors are buggy and cannot report properly
         end
       end
     end

--- a/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
+++ b/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
@@ -100,7 +100,7 @@ module Riemann
             svc = "rabbitmq.queue.#{queue['vhost']}.#{queue['name']}"
             errs = []
 
-            errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && (queue['messages_ready']).positive? && (queue['consumers']).zero?
+            errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && queue['messages_ready'].positive? && queue['consumers'].zero?
 
             errs << "Queue has #{queue['messages_ready']} jobs" if (max_size_check_filter.nil? || queue['name'] !~ (max_size_check_filter)) && !queue['messages_ready'].nil? && (queue['messages_ready'] > opts[:max_queue_size])
 


### PR DESCRIPTION
`efivarfs` is a new type of filesystem to replace `sysfs` for
maintaining EFI variables.  It does not make sense to monitor it and
report its usage so add it to the default ignore list.
