### PR TITLE
Drop support for Ruby < 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'github_changelog_generator'
 gem 'maxmind-geoip2'
 gem 'racc'
+gem 'rackup'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'
@@ -15,14 +16,3 @@ gem 'rubocop-rake'
 gem 'rubocop-rspec'
 gem 'sinatra'
 gem 'webrick'
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  # XXX: Needed for Ruby 2.6 compatibility
-  #
-  # With Ruby 2.6 an older version of rakup is installed that cause other gems
-  # to be installed with a legacy version.
-  #
-  # Because rakup is only needed when using rack 3, we can just ignore this
-  # with Ruby 2.6.
-  gem 'rackup'
-end

--- a/riemann-tools.gemspec
+++ b/riemann-tools.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Collection of utilities which submit events to Riemann,'
   spec.homepage      = 'https://github.com/aphyr/riemann-tools'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.metadata['allowed_push_host']     = 'https://rubygems.org/'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/riemann/tools/http_check_spec.rb
+++ b/spec/riemann/tools/http_check_spec.rb
@@ -1,15 +1,7 @@
 # frozen_string_literal: true
 
 require 'openssl'
-begin
-  require 'rackup/handler/webrick'
-  RACK_HANDLER = Rackup::Handler::WEBrick
-rescue LoadError
-  # XXX: Needed for Ruby 2.6 compatibility
-  # Moved to the rackup gem in recent versions
-  require 'rack/handler/webrick'
-  RACK_HANDLER = Rack::Handler::WEBrick
-end
+require 'rackup/handler/webrick'
 require 'sinatra/base'
 require 'webrick'
 require 'webrick/https'
@@ -112,7 +104,7 @@ RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= 
           Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
         }
         @server = WEBrick::HTTPServer.new(server_options)
-        @server.mount('/', RACK_HANDLER, TestWebserver)
+        @server.mount('/', Rackup::Handler::WEBrick, TestWebserver)
         @started = false
         Thread.new { @server.start }
         Timeout.timeout(1) { sleep(0.1) until @started }
@@ -264,7 +256,7 @@ RSpec.describe Riemann::Tools::HttpCheck, if: Gem::Version.new(RUBY_VERSION) >= 
           SSLCertName: '/CN=example.com',
         }
         @server = WEBrick::HTTPServer.new(server_options)
-        @server.mount('/', RACK_HANDLER, TestWebserver)
+        @server.mount('/', Rackup::Handler::WEBrick, TestWebserver)
         @started = false
         Thread.new { @server.start }
         Timeout.timeout(1) { sleep(0.1) until @started }


### PR DESCRIPTION
Ruby 2.6 reached EOL on March 31, 2022.

Maintaining support of legacy versions of Ruby require time we can
better use for other projects, and make it harder for us to make sure
the project works correctly with up-to-date dependencies.

We are therefore dorpping support for this version of Ruby.
