### PR TITLE
Distinguish i2c devices in `riemann-hwmon`

### DIFF
--- a/lib/riemann/tools/health.rb
+++ b/lib/riemann/tools/health.rb
@@ -21,7 +21,7 @@ module Riemann
       opt :disk_warning_leniency, 'Disk warning threshold (amount of free space)', short: :none, default: '500G'
       opt :disk_critical_leniency, 'Disk critical threshold (amount of free space)', short: :none, default: '250G'
       opt :disk_ignorefs, 'A list of filesystem types to ignore',
-          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs squashfs tmpfs]
+          default: %w[anon_inodefs autofs cd9660 devfs devtmpfs efivarfs fdescfs iso9660 linprocfs linsysfs nfs overlay procfs squashfs tmpfs]
       opt :load_warning, 'Load warning threshold (load average / core)', default: 3.0
       opt :load_critical, 'Load critical threshold (load average / core)', default: 8.0
       opt :memory_warning, 'Memory warning threshold (fraction of RAM)', default: 0.85

--- a/lib/riemann/tools/hwmon.rb
+++ b/lib/riemann/tools/hwmon.rb
@@ -104,6 +104,8 @@ module Riemann
       def tick
         devices.each do |device|
           report(device.report)
+        rescue Errno::ENODATA
+          # Some sensors are buggy and cannot report properly
         end
       end
     end

--- a/spec/riemann/tools/hwmon/device_spec.rb
+++ b/spec/riemann/tools/hwmon/device_spec.rb
@@ -6,14 +6,32 @@ RSpec.describe Riemann::Tools::Hwmon::Device do
   subject { described_class.new(1, :temp, 2) }
 
   before do
+    allow(File).to receive(:realpath).with('/sys/class/hwmon/hwmon1/name').and_return(device_path)
     allow(File).to receive(:read).with('/sys/class/hwmon/hwmon1/name').and_return("i350bb\n")
-    allow(File).to receive(:read).with('/sys/class/hwmon/hwmon1/temp2_input').and_return("#{input}\n")
     allow(File).to receive(:read).with('/sys/class/hwmon/hwmon1/temp2_crit').and_return("96000\n")
     allow(File).to receive(:read).with('/sys/class/hwmon/hwmon1/temp2_lcrit').and_raise(Errno::ENOENT)
     allow(File).to receive(:read).with('/sys/class/hwmon/hwmon1/temp2_label').and_return("loc1\n")
   end
 
+  let(:device_path) { '/sys/devices/platform/coretemp.0/hwmon/hwmon1' }
+
+  describe '#name' do
+    context 'with a regular device' do
+      it { expect(subject.name).to eq('i350bb') }
+    end
+
+    context 'with an i2c device' do
+      let(:device_path) { '/sys/devices/pci0000:00/0000:00:1f.3/i2c-1/1-001a/hwmon/hwmon1' }
+
+      it { expect(subject.name).to eq('i350bb at i2c-1/1-001a') }
+    end
+  end
+
   describe '#report' do
+    before do
+      allow(File).to receive(:read).with('/sys/class/hwmon/hwmon1/temp2_input').and_return("#{input}\n")
+    end
+
     context 'when temperature is ok' do
       let(:input) { 31_000 }
 

--- a/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
+++ b/tools/riemann-rabbitmq/lib/riemann/tools/rabbitmq.rb
@@ -100,7 +100,7 @@ module Riemann
             svc = "rabbitmq.queue.#{queue['vhost']}.#{queue['name']}"
             errs = []
 
-            errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && (queue['messages_ready']).positive? && (queue['consumers']).zero?
+            errs << 'Queue has jobs but no consumers' if !queue['messages_ready'].nil? && queue['messages_ready'].positive? && queue['consumers'].zero?
 
             errs << "Queue has #{queue['messages_ready']} jobs" if (max_size_check_filter.nil? || queue['name'] !~ (max_size_check_filter)) && !queue['messages_ready'].nil? && (queue['messages_ready'] > opts[:max_queue_size])
 


### PR DESCRIPTION
When multiple identical i2c devices are present on a host (typical case for temperature sensors on memory modules), they overwrite each other metrics making monitoring unreliable.

Detect if the hwmon sensor is queried over i2c and if so add location information so that each device is reported with a different service.

Also include:
  - #303
  - #304
