### PR TITLE
Fix `riemann-md` not recognizing mdstat `auto-read-only` mode

### DIFF
--- a/lib/riemann/tools/mdstat_parser.y
+++ b/lib/riemann/tools/mdstat_parser.y
@@ -62,7 +62,7 @@ require 'riemann/tools/utils'
     until s.eos? do
       case
       when s.scan(/\n/)               then s.push_token(nil)
-      when s.scan(/\s+/)              then s.push_token(nil)
+      when s.scan(/[[:blank:]]+/)     then s.push_token(nil)
 
       when s.scan(/\([WJFSR]\)/)      then s.push_token(:DISK_STATUS)
       when s.scan(/<none>/)           then s.push_token(:NONE)

--- a/lib/riemann/tools/mdstat_parser.y
+++ b/lib/riemann/tools/mdstat_parser.y
@@ -1,5 +1,5 @@
 class Riemann::Tools::MdstatParser
-token ALGORITHM BITMAP BLOCKS BYTE_UNIT CHECK CHUNK DELAYED DISK_STATUS FINISH FLOAT IDENTIFIER INTEGER LEVEL MIN NONE PAGES PERSONALITIES PERSONALITY PENDING PROGRESS RECOVER RECOVERY REMOTE RESHAPE RESYNC SPEED SPEED_UNIT SUPER UNIT UNUSED_DEVICES
+token ALGORITHM AUTO_READ_ONLY BITMAP BLOCKS BYTE_UNIT CHECK CHUNK DELAYED DISK_STATUS FINISH FLOAT IDENTIFIER INTEGER LEVEL MIN NONE PAGES PERSONALITIES PERSONALITY PENDING PROGRESS RECOVER RECOVERY REMOTE RESHAPE RESYNC SPEED SPEED_UNIT SUPER UNIT UNUSED_DEVICES
 rule
   target: personalities devices unused_devices { result = val[1] }
 
@@ -11,7 +11,11 @@ rule
   devices: devices device { result = val[0].merge(val[1]) }
          |                { result = {} }
 
-  device: IDENTIFIER ':' IDENTIFIER PERSONALITY list_of_devices INTEGER BLOCKS super level '[' INTEGER '/' INTEGER ']' '[' IDENTIFIER ']' progress bitmap { result = { val[0][:value] => val[15][:value] } }
+  device: IDENTIFIER ':' IDENTIFIER auto_read_only PERSONALITY list_of_devices INTEGER BLOCKS super level '[' INTEGER '/' INTEGER ']' '[' IDENTIFIER ']' progress bitmap { result = { val[0][:value] => val[16][:value] } }
+
+  auto_read_only: '(' AUTO_READ_ONLY ')'
+                |
+                ;
 
   list_of_devices: list_of_devices device
                  | device
@@ -79,6 +83,7 @@ require 'riemann/tools/utils'
       when s.scan(/\[/)               then s.push_token('[')
       when s.scan(/]/)                then s.push_token(']')
 
+      when s.scan(/auto-read-only\b/) then s.push_token(:AUTO_READ_ONLY)
       when s.scan(/DELAYED\b/)        then s.push_token(:DELAYED)
       when s.scan(/KB\b/)             then s.push_token(:BYTE_UNIT)
       when s.scan(/K\/sec\b/)         then s.push_token(:SPEED_UNIT)

--- a/lib/riemann/tools/tls_check.rb
+++ b/lib/riemann/tools/tls_check.rb
@@ -24,7 +24,7 @@ module URI
   end
 end
 
-module Riemann
+module Riemann # rubocop:disable Style/OneClassPerFile
   module Tools
     class TLSCheck
       include Riemann::Tools

--- a/spec/fixtures/mdstat/example-14
+++ b/spec/fixtures/mdstat/example-14
@@ -1,0 +1,13 @@
+Personalities : [raid1] [raid0] [raid6] [raid5] [raid4] [raid10] 
+md0 : active (auto-read-only) raid1 nvme1n1p1[0] nvme0n1p1[1]
+      33520640 blocks super 1.2 [2/2] [UU]
+      	resync=PENDING
+      
+md2 : active raid1 nvme1n1p3[0] nvme0n1p3[1]
+      465370432 blocks super 1.2 [2/2] [UU]
+      bitmap: 4/4 pages [16KB], 65536KB chunk
+
+md1 : active raid1 nvme1n1p2[0] nvme0n1p2[1]
+      1046528 blocks super 1.2 [2/2] [UU]
+      
+unused devices: <none>

--- a/spec/riemann/tools/mdstat_parser_spec.rb
+++ b/spec/riemann/tools/mdstat_parser_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Riemann::Tools::MdstatParser do
     'example-11' => { 'md1' => '_UUUU_' },
     'example-12' => { 'md2' => 'UU', 'md3' => 'UU' },
     'example-13' => { 'md2' => 'UU', 'md3' => 'UU', 'md1' => 'UU' },
+    'example-14' => { 'md0' => 'UU', 'md2' => 'UU', 'md1' => 'UU' },
   }.each do |config, expected_data|
     describe(config) do
       let(:text) { File.read("spec/fixtures/mdstat/#{config}") }

--- a/tools/riemann-chronos/lib/riemann/tools/chronos.rb
+++ b/tools/riemann-chronos/lib/riemann/tools/chronos.rb
@@ -49,14 +49,14 @@ module Riemann
       def health_url
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:chronos_host]}:#{options[:chronos_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/metrics"
       end
 
       def jobs_url
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:chronos_host]}:#{options[:chronos_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/scheduler/jobs"
       end
 

--- a/tools/riemann-elasticsearch/lib/riemann/tools/elasticsearch.rb
+++ b/tools/riemann-elasticsearch/lib/riemann/tools/elasticsearch.rb
@@ -43,7 +43,7 @@ module Riemann
       def make_es_url(path)
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:es_host]}:#{options[:es_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/#{path}"
       end
 

--- a/tools/riemann-marathon/lib/riemann/tools/marathon.rb
+++ b/tools/riemann-marathon/lib/riemann/tools/marathon.rb
@@ -49,14 +49,14 @@ module Riemann
       def health_url
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:marathon_host]}:#{options[:marathon_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/metrics"
       end
 
       def apps_url
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:marathon_host]}:#{options[:marathon_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/v2/apps"
       end
 

--- a/tools/riemann-mesos/lib/riemann/tools/mesos.rb
+++ b/tools/riemann-mesos/lib/riemann/tools/mesos.rb
@@ -42,14 +42,14 @@ module Riemann
       def health_url
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:mesos_host]}:#{options[:mesos_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/metrics/snapshot"
       end
 
       def slaves_url
         path_prefix = options[:path_prefix]
         path_prefix[0] = '' if path_prefix[0] == '/'
-        path_prefix[path_prefix.length - 1] = '' if path_prefix[path_prefix.length - 1] == '/'
+        path_prefix[-1] = '' if path_prefix[-1] == '/'
         "http://#{options[:mesos_host]}:#{options[:mesos_port]}#{'/' if path_prefix.length.positive?}#{path_prefix}/master/slaves"
       end
 


### PR DESCRIPTION
When an array is initially assembled, it is placed in auto-read-only mode and will switch to read-write on first write.  For a swap device, that may be a long time after the array is created, so we should support this mode and make sure it does not prevent from reporting the state of other arrays.

