### PR TITLE
Fix copying user/password when following redirects

### DIFF
--- a/lib/riemann/tools/http_check.rb
+++ b/lib/riemann/tools/http_check.rb
@@ -254,8 +254,8 @@ module Riemann
         res.scheme   ||= uri.scheme
         res.host     ||= uri.host
         res.port     ||= uri.port
-        res.user     ||= res.user
-        res.password ||= res.password
+        res.user     ||= uri.user
+        res.password ||= uri.password
 
         res
       end


### PR DESCRIPTION
rubocop noticed unexpected self-assignations.  These values should be
copied from the original uri if present.
